### PR TITLE
Refactor git-status.ts duplication, git-conflict.ts process.exit coupling, and bump-version.ts JSON parsing #178

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"version": "0.82.0",
+	"version": "0.83.0",
 	"name": "@joshuafolkken/kit",
 	"type": "module",
 	"license": "MIT",

--- a/scripts/bump-version.test.ts
+++ b/scripts/bump-version.test.ts
@@ -7,7 +7,7 @@ vi.mock('node:fs', () => ({
 	writeFileSync: vi.fn(),
 }))
 
-const MOCK_PKG = JSON.stringify({ name: 'kit', version: '1.2.3' })
+const MOCK_PKG = JSON.stringify({ name: 'kit', version: '1.2.3' }, undefined, '\t')
 const ORIGINAL_ARGV = process.argv[2] ?? ''
 
 afterEach(() => {
@@ -61,6 +61,27 @@ describe('bump-version.ts — version increment', () => {
 		expect(vi.mocked(write_file_sync)).toHaveBeenCalledWith(
 			expect.any(String),
 			expect.stringContaining('"version": "2.0.0"'),
+		)
+	})
+})
+
+describe('bump-version.ts — key order preservation', () => {
+	beforeEach(() => {
+		vi.resetModules()
+	})
+
+	it('preserves original key order after version bump', async () => {
+		process.argv[2] = 'patch'
+
+		const { readFileSync: read_file_sync, writeFileSync: write_file_sync } = await import('node:fs')
+
+		vi.mocked(read_file_sync).mockReturnValue(MOCK_PKG)
+
+		await import('./bump-version')
+
+		expect(vi.mocked(write_file_sync)).toHaveBeenCalledWith(
+			expect.any(String),
+			expect.stringMatching(/"name"[\s\S]*"version"/u),
 		)
 	})
 })

--- a/scripts/bump-version.ts
+++ b/scripts/bump-version.ts
@@ -1,8 +1,4 @@
 #!/usr/bin/env tsx
-/**
- * Bump package.json version without invoking npm.
- * Usage: tsx scripts/bump-version.ts [major|minor|patch]
- */
 import { readFileSync, writeFileSync } from 'node:fs'
 import path from 'node:path'
 import { package_with_version_schema } from './schemas'
@@ -20,8 +16,8 @@ const MINOR_INDEX = 2
 const PATCH_INDEX = 3
 
 const package_path = path.join(process.cwd(), 'package.json')
-const raw = package_with_version_schema.parse(JSON.parse(readFileSync(package_path, 'utf8')))
-const { version } = raw
+const file_content = readFileSync(package_path, 'utf8')
+const { version } = package_with_version_schema.parse(JSON.parse(file_content))
 const match = /^(\d+)\.(\d+)\.(\d+)$/u.exec(version)
 
 if (!match) {
@@ -59,6 +55,7 @@ switch (bump) {
 	}
 }
 
-raw.version = new_version
-writeFileSync(package_path, `${JSON.stringify(raw, undefined, '\t')}\n`)
+const updated_content = file_content.replace(/("version"\s*:\s*)"[^"]*"/u, `$1"${new_version}"`)
+
+writeFileSync(package_path, updated_content)
 console.info(new_version)

--- a/scripts/git/git-conflict.test.ts
+++ b/scripts/git/git-conflict.test.ts
@@ -27,30 +27,30 @@ afterEach(() => {
 })
 
 describe('git_conflict.check_pr_status_for_errors — no conflicts', () => {
-	it('returns false when pr_view returns empty string', async () => {
+	it('resolves without error when pr_view returns empty string', async () => {
 		mocked_pr_view.mockResolvedValue('')
 
-		expect(await git_conflict.check_pr_status_for_errors(BRANCH_NAME)).toBe(false)
+		await expect(git_conflict.check_pr_status_for_errors(BRANCH_NAME)).resolves.toBeUndefined()
 	})
 
-	it('returns false when pr_view throws', async () => {
+	it('resolves without error when pr_view throws', async () => {
 		mocked_pr_view.mockRejectedValue(new Error('not found'))
 
-		expect(await git_conflict.check_pr_status_for_errors(BRANCH_NAME)).toBe(false)
+		await expect(git_conflict.check_pr_status_for_errors(BRANCH_NAME)).resolves.toBeUndefined()
 	})
 
-	it('returns false when PR JSON is invalid', async () => {
+	it('resolves without error when PR JSON is invalid', async () => {
 		mocked_pr_view.mockResolvedValue('not-valid-json')
 
-		expect(await git_conflict.check_pr_status_for_errors(BRANCH_NAME)).toBe(false)
+		await expect(git_conflict.check_pr_status_for_errors(BRANCH_NAME)).resolves.toBeUndefined()
 	})
 
-	it('returns false when PR is mergeable with clean state', async () => {
+	it('resolves without error when PR is mergeable with clean state', async () => {
 		const pr_info = JSON.stringify({ mergeable: true, mergeStateStatus: MERGE_STATE_CLEAN })
 
 		mocked_pr_view.mockResolvedValue(pr_info)
 
-		expect(await git_conflict.check_pr_status_for_errors(BRANCH_NAME)).toBe(false)
+		await expect(git_conflict.check_pr_status_for_errors(BRANCH_NAME)).resolves.toBeUndefined()
 	})
 })
 

--- a/scripts/git/git-conflict.ts
+++ b/scripts/git/git-conflict.ts
@@ -68,7 +68,6 @@ function display_conflict_warning(): void {
 	console.error(CONFLICT_MESSAGE)
 	console.error('Please resolve the conflicts and update the PR.')
 	console.error('')
-	process.exit(1)
 }
 
 async function get_pr_info_safe(branch_name: string): Promise<string | undefined> {
@@ -81,20 +80,14 @@ async function get_pr_info_safe(branch_name: string): Promise<string | undefined
 	}
 }
 
-async function check_pr_status_for_errors(branch_name: string): Promise<boolean> {
+async function check_pr_status_for_errors(branch_name: string): Promise<void> {
 	const pr_info_json = await get_pr_info_safe(branch_name)
-
-	if (pr_info_json === undefined) {
-		return false
-	}
+	if (pr_info_json === undefined) return
 
 	if (has_conflicts(pr_info_json)) {
 		display_conflict_warning()
-
-		return true
+		process.exit(1)
 	}
-
-	return false
 }
 
 const git_conflict = {

--- a/scripts/git/git-pr.test.ts
+++ b/scripts/git/git-pr.test.ts
@@ -76,7 +76,7 @@ describe('git_pr.create — post-watch conflict check behavior', () => {
 
 	it('calls conflict check when watch completes without timeout', async () => {
 		vi.mocked(git_gh_command.pr_checks_watch).mockResolvedValue({ timed_out: false })
-		vi.mocked(git_conflict.check_pr_status_for_errors).mockResolvedValue(false)
+		vi.mocked(git_conflict.check_pr_status_for_errors).mockResolvedValue()
 
 		await git_pr.create(PR_TITLE, PR_BODY, BRANCH)
 

--- a/scripts/git/git-pr.ts
+++ b/scripts/git/git-pr.ts
@@ -67,14 +67,8 @@ async function handle_watch_error(branch_name: string, error: unknown): Promise<
 }
 
 async function check_and_display_status(branch_name: string): Promise<void> {
-	const has_errors = await git_conflict.check_pr_status_for_errors(branch_name)
-
-	if (has_errors) {
-		git_pr_messages.display_error_message()
-	} else {
-		git_pr_messages.display_success_message()
-	}
-
+	await git_conflict.check_pr_status_for_errors(branch_name)
+	git_pr_messages.display_success_message()
 	await display_pr_url_if_available(branch_name)
 }
 

--- a/scripts/git/git-status.ts
+++ b/scripts/git/git-status.ts
@@ -15,23 +15,19 @@ function is_unstaged_file(line: string): boolean {
 	return line.length >= REQUIRED_STATUS_LENGTH && line[STAGED_STATUS_INDEX] !== ' '
 }
 
-function has_unstaged_files(status_output: string): boolean {
-	const lines = status_output
-		.split(/\r?\n/u)
-		.map((line) => line.trimEnd())
-		.filter((line) => line.length > 0)
-
-	const has_untracked = lines.some((line) => is_untracked_file(line))
-	const has_unstaged = lines.some((line) => is_unstaged_file(line))
-
-	return has_untracked || has_unstaged
-}
-
 function parse_status_lines(status_output: string): Array<string> {
 	return status_output
 		.split(/\r?\n/u)
 		.map((line) => line.trimEnd())
 		.filter((line) => line.length > 0)
+}
+
+function has_unstaged_files(status_output: string): boolean {
+	const lines = parse_status_lines(status_output)
+	const has_untracked = lines.some((line) => is_untracked_file(line))
+	const has_unstaged = lines.some((line) => is_unstaged_file(line))
+
+	return has_untracked || has_unstaged
 }
 
 function is_staged_file(line: string): boolean {


### PR DESCRIPTION
## Summary
- `git-status.ts`: `has_unstaged_files()` now calls `parse_status_lines()` instead of duplicating the split/trimEnd/filter logic
- `git-conflict.ts`: `display_conflict_warning()` no longer calls `process.exit(1)`; moved to `check_pr_status_for_errors()`, which now returns `Promise<void>`; `git-pr.ts` simplified accordingly
- `bump-version.ts`: replaced `JSON.stringify(raw, undefined, '\\t')` with regex-based version-line replacement to preserve key order; removed multi-line comment block

## Test plan
- [ ] Regression test for key-order preservation in `bump-version.test.ts`
- [ ] Existing tests in `git-conflict.test.ts`, `git-pr.test.ts`, and `git-status.test.ts` updated for new signatures

🤖 Generated with [Claude Code](https://claude.com/claude-code)