### PR TITLE
Narrow SonarQube exclusions to restore static analysis coverage over scripts/ #180

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"version": "0.84.0",
+	"version": "0.85.0",
 	"name": "@joshuafolkken/kit",
 	"type": "module",
 	"license": "MIT",

--- a/scripts/sonar-config.test.ts
+++ b/scripts/sonar-config.test.ts
@@ -29,7 +29,11 @@ describe(SONAR_PROPERTIES_FILE, () => {
 		expect(exclusions).toContain('.claude/**')
 	})
 
-	it('excludes scripts/ tooling directory from analysis', () => {
-		expect(exclusions).toContain('scripts/**')
+	it('excludes scripts-ai/ AI automation from analysis', () => {
+		expect(exclusions).toContain('scripts-ai/**')
+	})
+
+	it('does not exclude scripts/ core package code from analysis', () => {
+		expect(exclusions).not.toContain('scripts/**')
 	})
 })

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -11,10 +11,10 @@ sonar.lang.patterns.css=**/*.css,**/*.less,**/*.scss,**/*.sass
 # Disable coverage checks
 sonar.coverage.exclusions=**/*
 
-# Exclude upstream-synced bootstrap scripts and dev/CI tooling from analysis.
+# Exclude upstream-synced bootstrap scripts and AI automation from analysis.
 # .claude/ hosts setup shell scripts synced from joshuafolkken/tasks (must not drift).
-# scripts/ hosts git / issue / overrides / telegram workflow tooling — not production code.
-sonar.exclusions=.claude/**,scripts/**
+# scripts-ai/ hosts Telegram / git-followup workflow automation scripts.
+sonar.exclusions=.claude/**,scripts-ai/**
 
 # Files to exclude from the duplicate check
 # sonar.cpd.exclusions=**/src/lib/data/questions.ts,**/src/lib/data/phrases/**/*.ts


### PR DESCRIPTION
## Summary
- Changed `sonar.exclusions` from `.claude/**,scripts/**` to `.claude/**,scripts-ai/**`
- Restores SonarQube analysis over `scripts/` (init, sync, git automation, version management)
- Updated `sonar-config.test.ts` to verify new exclusion behavior

## Test plan
- [ ] Unit tests updated and passing
- [ ] SonarQube CI run completes without critical threshold failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)