### PR TITLE
Make CI PR check wait timeout configurable via JOSH_CI_TIMEOUT_SECONDS #181

### DIFF
--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -9,4 +9,5 @@ words:
   - myrepo
   - ncurc
   - shellcheck
+  - unstub
   - vercel

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"version": "0.85.0",
+	"version": "0.86.0",
 	"name": "@joshuafolkken/kit",
 	"type": "module",
 	"license": "MIT",

--- a/scripts/git/git-pr-checks.test.ts
+++ b/scripts/git/git-pr-checks.test.ts
@@ -1,7 +1,10 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
+	compute_max_attempts,
+	DEFAULT_MAX_ATTEMPTS,
 	DEFAULT_STABLE_READS,
 	evaluate_pr_state,
+	get_configured_max_attempts,
 	parse_pr_state_snapshot,
 	parse_repo_name_from_package,
 	wait_for_pr_success,
@@ -259,5 +262,49 @@ describe('wait_for_pr_success — failure and timeout', () => {
 				required_stable_reads: DEFAULT_STABLE_READS,
 			}),
 		).rejects.toThrow(/Timed out/u)
+	})
+})
+
+describe('compute_max_attempts', () => {
+	it('returns 18 for 180s timeout and 10s interval', () => {
+		expect(compute_max_attempts(180, 10_000)).toBe(18)
+	})
+
+	it('rounds up when timeout does not divide evenly', () => {
+		expect(compute_max_attempts(181, 10_000)).toBe(19)
+	})
+
+	it('returns 3 for 30s timeout and 10s interval', () => {
+		expect(compute_max_attempts(30, 10_000)).toBe(3)
+	})
+})
+
+describe('get_configured_max_attempts', () => {
+	afterEach(() => {
+		vi.unstubAllEnvs()
+	})
+
+	it('returns DEFAULT_MAX_ATTEMPTS when env var is not set', () => {
+		expect(get_configured_max_attempts()).toBe(DEFAULT_MAX_ATTEMPTS)
+	})
+
+	it('returns computed value when env var is a valid positive number', () => {
+		vi.stubEnv('JOSH_CI_TIMEOUT_SECONDS', '60')
+		expect(get_configured_max_attempts()).toBe(6)
+	})
+
+	it('returns DEFAULT_MAX_ATTEMPTS when env var is zero', () => {
+		vi.stubEnv('JOSH_CI_TIMEOUT_SECONDS', '0')
+		expect(get_configured_max_attempts()).toBe(DEFAULT_MAX_ATTEMPTS)
+	})
+
+	it('returns DEFAULT_MAX_ATTEMPTS when env var is negative', () => {
+		vi.stubEnv('JOSH_CI_TIMEOUT_SECONDS', '-30')
+		expect(get_configured_max_attempts()).toBe(DEFAULT_MAX_ATTEMPTS)
+	})
+
+	it('returns DEFAULT_MAX_ATTEMPTS when env var is not a number', () => {
+		vi.stubEnv('JOSH_CI_TIMEOUT_SECONDS', 'abc')
+		expect(get_configured_max_attempts()).toBe(DEFAULT_MAX_ATTEMPTS)
 	})
 })

--- a/scripts/git/git-pr-checks.ts
+++ b/scripts/git/git-pr-checks.ts
@@ -3,8 +3,25 @@ import { evaluate_pr_state, type PrEvaluation } from './git-pr-checks-eval'
 import { parse_pr_state_snapshot, type PrStateSnapshot } from './git-pr-checks-parse'
 import { package_name_schema } from './schemas'
 
+const SECONDS_TO_MS = 1000
 const CHECK_WAIT_INTERVAL_MS = 10_000
-const CHECK_MAX_ATTEMPTS = 18
+const DEFAULT_TIMEOUT_SECONDS = 180
+
+function compute_max_attempts(timeout_seconds: number, interval_ms: number): number {
+	return Math.ceil(timeout_seconds / (interval_ms / SECONDS_TO_MS))
+}
+
+const DEFAULT_MAX_ATTEMPTS = compute_max_attempts(DEFAULT_TIMEOUT_SECONDS, CHECK_WAIT_INTERVAL_MS)
+
+function get_configured_max_attempts(): number {
+	const environment_seconds = Number(process.env['JOSH_CI_TIMEOUT_SECONDS'])
+
+	return Number.isFinite(environment_seconds) && environment_seconds > 0
+		? compute_max_attempts(environment_seconds, CHECK_WAIT_INTERVAL_MS)
+		: DEFAULT_MAX_ATTEMPTS
+}
+
+const CHECK_MAX_ATTEMPTS = get_configured_max_attempts()
 const DEFAULT_STABLE_READS = 2
 
 type PrStateFetcher = (branch_name: string) => Promise<PrStateSnapshot>
@@ -110,7 +127,15 @@ const git_pr_checks = {
 	wait_for_pr_success: wait_for_pr_success_default,
 }
 
-export { git_pr_checks, parse_repo_name_from_package, wait_for_pr_success, DEFAULT_STABLE_READS }
+export {
+	git_pr_checks,
+	parse_repo_name_from_package,
+	wait_for_pr_success,
+	compute_max_attempts,
+	get_configured_max_attempts,
+	DEFAULT_STABLE_READS,
+	DEFAULT_MAX_ATTEMPTS,
+}
 export type { PrStateFetcher }
 export { evaluate_pr_state } from './git-pr-checks-eval'
 export type { PrEvaluation } from './git-pr-checks-eval'


### PR DESCRIPTION
## Summary
- Replace hardcoded `CHECK_MAX_ATTEMPTS = 18` with a computed value derived from `JOSH_CI_TIMEOUT_SECONDS` env var (default 180 s → 18 attempts)
- Add `compute_max_attempts(timeout_seconds, interval_ms)` pure helper and `get_configured_max_attempts()` that reads the env var
- Export both functions plus `DEFAULT_MAX_ATTEMPTS` for testability; add 8 new unit tests covering happy path, rounding, invalid/zero/negative env values

## Test plan
- [ ] `pnpm josh test:unit` — all 631 tests pass including new `compute_max_attempts` and `get_configured_max_attempts` suites
- [ ] Set `JOSH_CI_TIMEOUT_SECONDS=60` and verify `pnpm josh followup` uses 6 max attempts instead of 18

🤖 Generated with [Claude Code](https://claude.com/claude-code)