### PR TITLE
Align CI workflows and distribute ci.yml template via josh init

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,9 +68,9 @@ jobs:
         run: pnpm exec vitest run
 
   security:
-    name: Security
+    name: Security Audit
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 3
     steps:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -104,7 +104,9 @@ jobs:
     needs: e2e-detect
     if: needs.e2e-detect.outputs.enabled == 'true'
     runs-on: ubuntu-latest
-    container: mcr.microsoft.com/playwright:v1.59.1-noble
+    container:
+      image: mcr.microsoft.com/playwright:v1.59.1-noble
+      options: --user root
     timeout-minutes: 10
     # Playwright preview は localhost:4173。ワークフロー共通の BETTER_AUTH_URL（本番）を
     # 引き継ぐと Better Auth が origin を拒否する（CI E2E では本番 URL は使わない）。

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"version": "0.149.0",
+	"version": "0.150.0",
 	"name": "@joshuafolkken/kit",
 	"type": "module",
 	"license": "MIT",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1175,8 +1175,8 @@ packages:
   devalue@5.7.1:
     resolution: {integrity: sha512-MUbZ586EgQqdRnC4yDrlod3BEdyvE4TapGYHMW2CiaW+KkkFmWEFqBUaLltEZCGi0iFXCEjRF0OjF0DV2QHjOA==}
 
-  electron-to-chromium@1.5.351:
-    resolution: {integrity: sha512-9D7Iqx8RImSvCnOsj86rCH6eQjZFQoM04Jn6HnZVM0Nu/G58/gmKYQ1d12MZTbjQbQSTGI8nwEy07ErsA2slLA==}
+  electron-to-chromium@1.5.352:
+    resolution: {integrity: sha512-9wHk8x6dyuimoe18EdiDPWKExNdxYqo4fn4FwOVVper6RxT3cmpBwBkWWfSOCYJjQdIco/nPhJhNLmn4Ufg1Yg==}
 
   env-paths@4.0.0:
     resolution: {integrity: sha512-pxP8eL2SwwaTRi/KHYwLYXinDs7gL3jxFcBYmEdYfZmZXbaVDvdppd0XBU8qVz03rDfKZMXg1omHCbsJjZrMsw==}
@@ -2914,7 +2914,7 @@ snapshots:
     dependencies:
       baseline-browser-mapping: 2.10.27
       caniuse-lite: 1.0.30001792
-      electron-to-chromium: 1.5.351
+      electron-to-chromium: 1.5.352
       node-releases: 2.0.38
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
@@ -3067,7 +3067,7 @@ snapshots:
 
   devalue@5.7.1: {}
 
-  electron-to-chromium@1.5.351: {}
+  electron-to-chromium@1.5.352: {}
 
   env-paths@4.0.0:
     dependencies:

--- a/scripts/init-ai-copy.test.ts
+++ b/scripts/init-ai-copy.test.ts
@@ -24,6 +24,9 @@ vi.mock('./init-logic', () => ({
 	init_logic: {
 		transform_prompt_paths: vi.fn().mockImplementation((content: string) => content),
 		get_ai_copy_files: vi.fn().mockReturnValue(['CLAUDE.md']),
+		get_ai_copy_file_mappings: vi
+			.fn()
+			.mockReturnValue([{ src: 'templates/workflows/ci.yml', dest: '.github/workflows/ci.yml' }]),
 		get_ai_copy_directories: vi.fn().mockReturnValue(['prompts']),
 	},
 }))
@@ -40,6 +43,7 @@ const { init_ai_copy } = await import('./init-ai-copy')
 const SRC_PATH = '/pkg/CLAUDE.md'
 const DEST_PATH = '/project/CLAUDE.md'
 const RAW_CONTENT = 'raw content'
+const MAPPING_DEST_PATH = '/project/.github/workflows/ci.yml'
 
 describe('init_ai_copy.copy_ai_file — write behavior', () => {
 	it('writes transformed content to destination path', () => {
@@ -67,6 +71,34 @@ describe('init_ai_copy.run_ai_copies — skip behavior', () => {
 		init_ai_copy.run_ai_copies()
 
 		expect(write_file_mock).not.toHaveBeenCalled()
+		vi.restoreAllMocks()
+	})
+})
+
+describe('init_ai_copy.run_ai_copies — file mapping behavior', () => {
+	it('writes mapping destination when it does not exist', () => {
+		exists_sync_mock.mockReturnValue(false)
+		vi.spyOn(console, 'info').mockImplementation(() => {
+			/* suppress */
+		})
+		write_file_mock.mockClear()
+
+		init_ai_copy.run_ai_copies()
+
+		expect(write_file_mock).toHaveBeenCalledWith(MAPPING_DEST_PATH, expect.any(String))
+		vi.restoreAllMocks()
+	})
+
+	it('does not write mapping destination when it already exists', () => {
+		exists_sync_mock.mockReturnValue(true)
+		vi.spyOn(console, 'info').mockImplementation(() => {
+			/* suppress */
+		})
+		write_file_mock.mockClear()
+
+		init_ai_copy.run_ai_copies()
+
+		expect(write_file_mock).not.toHaveBeenCalledWith(MAPPING_DEST_PATH, expect.any(String))
 		vi.restoreAllMocks()
 	})
 })

--- a/scripts/init-ai-copy.ts
+++ b/scripts/init-ai-copy.ts
@@ -11,19 +11,33 @@ function copy_ai_file(source_path: string, destination_path: string): void {
 	writeFileSync(destination_path, init_logic.transform_prompt_paths(content))
 }
 
-function execute_ai_file_copy(filename: string): boolean {
-	const destination_path = path.join(PROJECT_ROOT, filename)
-
+function execute_copy_if_absent(
+	source_path: string,
+	destination_path: string,
+	label: string,
+): boolean {
 	if (existsSync(destination_path)) {
-		console.info(`  ⏭ skipped   ${filename} (already exists — run josh sync to update)`)
+		console.info(`  ⏭ skipped   ${label} (already exists — run josh sync to update)`)
 
 		return true
 	}
 
-	copy_ai_file(package_path(filename), destination_path)
-	console.info(`  ✔ created   ${filename}`)
+	copy_ai_file(source_path, destination_path)
+	console.info(`  ✔ created   ${label}`)
 
 	return false
+}
+
+function execute_ai_file_copy(filename: string): boolean {
+	return execute_copy_if_absent(package_path(filename), path.join(PROJECT_ROOT, filename), filename)
+}
+
+function execute_ai_file_mapping(source: string, destination: string): boolean {
+	return execute_copy_if_absent(
+		package_path(source),
+		path.join(PROJECT_ROOT, destination),
+		destination,
+	)
 }
 
 function execute_ai_directory_copy(directory_name: string): boolean {
@@ -45,10 +59,13 @@ function run_ai_copies(): void {
 	const file_skips = init_logic
 		.get_ai_copy_files()
 		.map((filename) => execute_ai_file_copy(filename))
+	const mapping_skips = init_logic
+		.get_ai_copy_file_mappings()
+		.map(({ src: source, dest: destination }) => execute_ai_file_mapping(source, destination))
 	const directory_skips = init_logic
 		.get_ai_copy_directories()
 		.map((directory_name) => execute_ai_directory_copy(directory_name))
-	const has_skips = [...file_skips, ...directory_skips].some(Boolean)
+	const has_skips = [...file_skips, ...mapping_skips, ...directory_skips].some(Boolean)
 
 	init_sonar.copy_sonar_with_template()
 

--- a/scripts/init-logic.test.ts
+++ b/scripts/init-logic.test.ts
@@ -301,27 +301,6 @@ describe('cspell sveltekit.yaml content', () => {
 	})
 })
 
-describe('ci.yml template NOSONAR', () => {
-	const CI_YML_PATH = path.join(PACKAGE_ROOT, 'templates', 'workflows', 'ci.yml')
-	const CI_YML_CONTENT = readFileSync(CI_YML_PATH, 'utf8')
-
-	it('has NOSONAR on playwright install-deps line', () => {
-		const install_deps_line = CI_YML_CONTENT.split('\n').find((ci_line) =>
-			ci_line.includes('playwright install-deps'),
-		)
-
-		expect(install_deps_line).toContain('NOSONAR')
-	})
-
-	it('has NOSONAR on playwright install chromium line', () => {
-		const install_line = CI_YML_CONTENT.split('\n').find((ci_line) =>
-			ci_line.includes('playwright install chromium'),
-		)
-
-		expect(install_line).toContain('NOSONAR')
-	})
-})
-
 describe('gitignore template content', () => {
 	const GITIGNORE_TEMPLATE_PATH = path.join(PACKAGE_ROOT, 'templates', 'gitignore')
 	const GITIGNORE_CONTENT = readFileSync(GITIGNORE_TEMPLATE_PATH, 'utf8')

--- a/templates/workflows/ci.yml
+++ b/templates/workflows/ci.yml
@@ -18,6 +18,12 @@ jobs:
   checks:
     name: Checks
     runs-on: ubuntu-latest
+    # Playwright system dependencies and Chromium are pre-installed in this image,
+    # eliminating the slow `playwright install-deps` step. Keep the image tag in
+    # sync with @playwright/test in package.json whenever Playwright is upgraded.
+    container:
+      image: mcr.microsoft.com/playwright:v1.59.1-noble
+      options: --user root
     timeout-minutes: 8
     steps:
       - name: Checkout code
@@ -52,11 +58,6 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: pnpm install --frozen-lockfile --ignore-scripts
 
-      - name: Run security audit
-        uses: google/osv-scanner-action/osv-scanner-action@c51854704019a247608d928f370c98740469d4b5 # v2.3.5
-        with:
-          scan-args: --lockfile=pnpm-lock.yaml
-
       - name: Run spell check
         run: pnpm exec cspell . --dot
 
@@ -80,6 +81,19 @@ jobs:
 
       - name: Check bundle size
         run: pnpm size-limit
+
+  security:
+    name: Security Audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Run security audit
+        uses: google/osv-scanner-action/osv-scanner-action@c51854704019a247608d928f370c98740469d4b5 # v2.3.5
+        with:
+          scan-args: --lockfile=pnpm-lock.yaml
 
   e2e-detect:
     name: Detect E2E
@@ -105,6 +119,12 @@ jobs:
     needs: e2e-detect
     if: needs.e2e-detect.outputs.enabled == 'true'
     runs-on: ubuntu-latest
+    # Playwright system dependencies and Chromium are pre-installed in this image.
+    # Keep the image tag in sync with @playwright/test in package.json whenever
+    # Playwright is upgraded.
+    container:
+      image: mcr.microsoft.com/playwright:v1.59.1-noble
+      options: --user root
     timeout-minutes: 10
     # Playwright preview は localhost:4173。ワークフロー共通の BETTER_AUTH_URL（本番）を
     # 引き継ぐと Better Auth が origin を拒否する（CI E2E では本番 URL は使わない）。
@@ -136,16 +156,6 @@ jobs:
             ${{ runner.os }}-build-cache-e2e-${{ hashFiles('pnpm-lock.yaml') }}-
             ${{ runner.os }}-build-cache-e2e-
 
-      - name: Setup Playwright cache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        id: playwright-cache
-        with:
-          path: |
-            ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-cache-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-playwright-cache-
-
       - name: Setup safe-chain
         run: pnpm dlx @aikidosec/safe-chain@1.5.1 setup-ci
 
@@ -153,13 +163,6 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: pnpm install --frozen-lockfile --ignore-scripts
-
-      - name: Install Playwright system dependencies
-        run: pnpm exec playwright install-deps chromium # NOSONAR - installing browsers, not running lifecycle scripts
-
-      - name: Install Playwright browsers
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: pnpm exec playwright install chromium # NOSONAR - installing browsers, not running lifecycle scripts
 
       - name: Build application
         env:


### PR DESCRIPTION
closes #337

## Summary
- Add `get_ai_copy_file_mappings()` to `run_ai_copies()` in `init-ai-copy.ts` so `templates/workflows/ci.yml` → `.github/workflows/ci.yml` and `templates/gitignore` → `.gitignore` are now distributed by `josh init` (previously only `josh sync` handled these)
- Extract `execute_copy_if_absent` helper to eliminate duplication between file and mapping copy paths
- Align `.github/workflows/ci.yml` (kit repo CI) with the template: security job timeout 5→3 min, rename to "Security Audit", expand `e2e` container spec to long form with `--user root`
- Update `templates/workflows/ci.yml` to use pre-installed Playwright container in both `checks` and `e2e` jobs, eliminating explicit install steps
- Remove stale NOSONAR tests for `playwright install-deps` / `playwright install chromium` (those steps no longer exist in the template)

## Test plan
- [ ] `pnpm exec vitest run` — all 951 tests pass
- [ ] CI green on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)