### PR TITLE
Simplify SonarCloud CPD exclusion patterns by removing redundant svelte.spec.ts entry #360

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"version": "0.160.0",
+	"version": "0.161.0",
 	"name": "@joshuafolkken/kit",
 	"type": "module",
 	"license": "MIT",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -16,7 +16,7 @@ sonar.coverage.exclusions=**/*
 sonar.exclusions=.claude/**
 
 # Files to exclude from the duplicate check
-sonar.cpd.exclusions=**/*.spec.ts,**/*.svelte.spec.ts,**/*.test.ts,**/*.e2e.ts
+sonar.cpd.exclusions=**/*.test.ts,**/*.spec.ts,**/*.e2e.ts
 
 # Use SonarCloud-compatible tsconfig
 sonar.typescript.tsconfigPath=tsconfig.sonar.json

--- a/templates/sonar-project.properties
+++ b/templates/sonar-project.properties
@@ -17,7 +17,7 @@ sonar.coverage.exclusions=**/*
 sonar.exclusions=.claude/**,scripts/**
 
 # Files to exclude from the duplicate check
-sonar.cpd.exclusions=**/*.spec.ts,**/*.svelte.spec.ts,**/*.test.ts,**/*.e2e.ts
+sonar.cpd.exclusions=**/*.test.ts,**/*.spec.ts,**/*.e2e.ts
 
 # Use SonarCloud-compatible tsconfig
 sonar.typescript.tsconfigPath=tsconfig.sonar.json


### PR DESCRIPTION
closes #360