### PR TITLE
eslint/sveltekit: ship a default allowList for import/extensions so consumers don't need to override (.js / .json / .opus / .svelte) #417

### DIFF
--- a/eslint/rules/import.js
+++ b/eslint/rules/import.js
@@ -46,16 +46,21 @@ export const import_rules = {
 	// 匿名デフォルトエクスポートを禁止
 	'import/no-anonymous-default-export': 'error',
 	// インポートの際に拡張子を必須化/禁止
+	// `.js` / `.json` / `.svelte` は解決に必須なので always を強制する
+	// (Three.js deep imports / JSON modules / Svelte components — ドロップすると resolver が壊れる)
+	// `.opus` 等の game-asset 拡張子も Vite が URL に変換するため always
 	'import/extensions': [
 		'error',
 		{
 			pattern: {
-				js: 'never',
+				js: 'always',
+				json: 'always',
 				ts: 'never',
 				svelte: 'always',
 				svg: 'always',
 				png: 'always',
 				webp: 'always',
+				opus: 'always',
 			},
 			ignorePackages: true,
 		},

--- a/eslint/sveltekit.test.ts
+++ b/eslint/sveltekit.test.ts
@@ -14,6 +14,14 @@ const EXPECTED_SVELTE_FILE_PATTERNS = [
 	'**/*.svelte.spec.ts',
 ] as const
 
+function build_config(): ReturnType<typeof create_sveltekit_config> {
+	return create_sveltekit_config({
+		gitignore_path: GITIGNORE_PATH,
+		tsconfig_root_dir: TSCONFIG_ROOT_DIR,
+		svelte_config: MOCK_SVELTE_CONFIG,
+	})
+}
+
 function find_routes_block(
 	config: ReturnType<typeof create_sveltekit_config>,
 ): (typeof config)[number] | undefined {
@@ -25,13 +33,20 @@ function find_routes_block(
 	)
 }
 
+function find_block_with_rule(
+	config: ReturnType<typeof create_sveltekit_config>,
+	rule_name: string,
+): (typeof config)[number] | undefined {
+	return config.find((block) => {
+		const rules = block.rules as Record<string, unknown> | undefined
+
+		return rules !== undefined && rule_name in rules
+	})
+}
+
 describe('create_sveltekit_config — routes block', () => {
 	it('applies ROUTE_NO_RESTRICTED_SYNTAX to route files', () => {
-		const config = create_sveltekit_config({
-			gitignore_path: GITIGNORE_PATH,
-			tsconfig_root_dir: TSCONFIG_ROOT_DIR,
-			svelte_config: MOCK_SVELTE_CONFIG,
-		})
+		const config = build_config()
 
 		const routes_block = find_routes_block(config)
 		const rules = routes_block?.rules as Record<string, unknown>
@@ -40,13 +55,28 @@ describe('create_sveltekit_config — routes block', () => {
 	})
 })
 
+describe('create_sveltekit_config — import/extensions allowList', () => {
+	it('bakes in js/json/svelte/opus allowList so consumers do not need to override', () => {
+		const config = build_config()
+
+		const block = find_block_with_rule(config, 'import/extensions')
+		const rules = block?.rules as Record<string, unknown>
+		const rule_value = rules['import/extensions'] as [
+			string,
+			{ pattern: { js: string; json: string; svelte: string; opus: string } },
+		]
+		const [, { pattern }] = rule_value
+
+		expect(pattern.js).toBe('always')
+		expect(pattern.json).toBe('always')
+		expect(pattern.svelte).toBe('always')
+		expect(pattern.opus).toBe('always')
+	})
+})
+
 describe('create_sveltekit_config — svelte file patterns', () => {
 	it('applies rules to svelte component and test files', () => {
-		const config = create_sveltekit_config({
-			gitignore_path: GITIGNORE_PATH,
-			tsconfig_root_dir: TSCONFIG_ROOT_DIR,
-			svelte_config: MOCK_SVELTE_CONFIG,
-		})
+		const config = build_config()
 
 		const svelte_block = config.find(
 			(block) =>

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"version": "0.185.0",
+	"version": "0.186.0",
 	"name": "@joshuafolkken/kit",
 	"type": "module",
 	"license": "MIT",


### PR DESCRIPTION
closes #417