### PR TITLE
eslint/sveltekit: extend unicorn/prevent-abbreviations allowList with idiomatic short identifiers (e, el, btn, idx, ctx, …) #418

### DIFF
--- a/eslint/sveltekit.js
+++ b/eslint/sveltekit.js
@@ -23,8 +23,8 @@ const SVELTEKIT_ROUTE_PATTERNS = [
 	String.raw`\+server\.ts$`,
 ]
 
-// 普遍的に理解されている短縮名は許可する
-// (rule の目的は `req`/`res`/`usr`/`cnt` 等の慣れない略語を弾くこと)
+// Allow universally understood short identifiers — the rule should catch
+// unfamiliar abbreviations like `req` / `res` / `usr` / `cnt`, not these.
 const PREVENT_ABBR_ALLOW_LIST = {
 	Props: true,
 	e: true, // event handler parameter

--- a/eslint/sveltekit.js
+++ b/eslint/sveltekit.js
@@ -23,6 +23,20 @@ const SVELTEKIT_ROUTE_PATTERNS = [
 	String.raw`\+server\.ts$`,
 ]
 
+// 普遍的に理解されている短縮名は許可する
+// (rule の目的は `req`/`res`/`usr`/`cnt` 等の慣れない略語を弾くこと)
+const PREVENT_ABBR_ALLOW_LIST = {
+	Props: true,
+	e: true, // event handler parameter
+	el: true, // DOM element
+	ctx: true, // canvas/Three.js/Svelte context
+	btn: true, // button element
+	idx: true, // loop index
+	opts: true, // options object
+	params: true, // SvelteKit +page.ts params
+	args: true, // function arguments
+}
+
 export function create_sveltekit_config({ gitignore_path, tsconfig_root_dir, svelte_config }) {
 	return defineConfig(
 		...create_base_config({ gitignore_path, tsconfig_root_dir }),
@@ -43,7 +57,7 @@ export function create_sveltekit_config({ gitignore_path, tsconfig_root_dir, sve
 					'error',
 					{ case: 'pascalCase', ignore: SVELTEKIT_ROUTE_PATTERNS },
 				],
-				'unicorn/prevent-abbreviations': ['error', { allowList: { Props: true } }],
+				'unicorn/prevent-abbreviations': ['error', { allowList: PREVENT_ABBR_ALLOW_LIST }],
 				'sonarjs/no-unused-collection': 'off',
 				...svelte_rules,
 			},

--- a/eslint/sveltekit.test.ts
+++ b/eslint/sveltekit.test.ts
@@ -44,6 +44,17 @@ function find_block_with_rule(
 	})
 }
 
+function find_svelte_files_block(
+	config: ReturnType<typeof create_sveltekit_config>,
+): (typeof config)[number] | undefined {
+	return config.find(
+		(block) =>
+			Array.isArray(block.files) &&
+			block.files.includes(EXPECTED_SVELTE_FILE_PATTERNS[0]) &&
+			block.files.includes(EXPECTED_SVELTE_FILE_PATTERNS[1]),
+	)
+}
+
 describe('create_sveltekit_config — routes block', () => {
 	it('applies ROUTE_NO_RESTRICTED_SYNTAX to route files', () => {
 		const config = build_config()
@@ -78,12 +89,7 @@ describe('create_sveltekit_config — svelte file patterns', () => {
 	it('applies rules to svelte component and test files', () => {
 		const config = build_config()
 
-		const svelte_block = config.find(
-			(block) =>
-				Array.isArray(block.files) &&
-				block.files.includes(EXPECTED_SVELTE_FILE_PATTERNS[0]) &&
-				block.files.includes(EXPECTED_SVELTE_FILE_PATTERNS[1]),
-		)
+		const svelte_block = find_svelte_files_block(config)
 
 		expect(svelte_block).toBeDefined()
 		expect(svelte_block?.files).toEqual(EXPECTED_SVELTE_FILE_PATTERNS)
@@ -94,5 +100,31 @@ describe('create_sveltekit_config — svelte file patterns', () => {
 			'error',
 			{ case: 'pascalCase', ignore: expect.any(Array) },
 		])
+	})
+})
+
+describe('create_sveltekit_config — unicorn/prevent-abbreviations allowList', () => {
+	it('allows idiomatic short identifiers (e, el, ctx, btn, idx, opts, params, args) plus Props', () => {
+		const config = build_config()
+
+		const svelte_block = find_svelte_files_block(config)
+		const rules = svelte_block?.rules as Record<string, unknown>
+		const rule_value = rules['unicorn/prevent-abbreviations'] as [
+			string,
+			{ allowList: Record<string, boolean> },
+		]
+		const [, { allowList: allow_list }] = rule_value
+
+		expect(allow_list).toMatchObject({
+			Props: true,
+			e: true,
+			el: true,
+			ctx: true,
+			btn: true,
+			idx: true,
+			opts: true,
+			params: true,
+			args: true,
+		})
 	})
 })

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"version": "0.186.0",
+	"version": "0.187.0",
 	"name": "@joshuafolkken/kit",
 	"type": "module",
 	"license": "MIT",


### PR DESCRIPTION
closes #418