### PR TITLE
eslint/sveltekit: configure unicorn/number-literal-case to match prettier (lowercase hex) #419

### DIFF
--- a/eslint/rules/unicorn.js
+++ b/eslint/rules/unicorn.js
@@ -59,6 +59,9 @@ export const unicorn_rules = {
 	'unicorn/no-useless-undefined': 'error',
 	// 数値セパレータのスタイルを統一
 	'unicorn/numeric-separators-style': 'error',
+	// 16進リテラルを lowercase に統一（prettier の hex 正規化と整合させ
+	// eslint↔prettier の無限 fix ループを防ぐ）
+	'unicorn/number-literal-case': ['error', { hexadecimalValue: 'lowercase' }],
 	// flatMapを優先
 	'unicorn/prefer-array-flat-map': 'error',
 	// Date.now()を優先

--- a/eslint/sveltekit.test.ts
+++ b/eslint/sveltekit.test.ts
@@ -37,7 +37,9 @@ function find_block_with_rule(
 	config: ReturnType<typeof create_sveltekit_config>,
 	rule_name: string,
 ): (typeof config)[number] | undefined {
-	return config.find((block) => {
+	// findLast: flat config applies later-wins, so the rightmost block
+	// with the rule is what actually takes effect.
+	return config.findLast((block) => {
 		const rules = block.rules as Record<string, unknown> | undefined
 
 		return rules !== undefined && rule_name in rules
@@ -100,6 +102,22 @@ describe('create_sveltekit_config — svelte file patterns', () => {
 			'error',
 			{ case: 'pascalCase', ignore: expect.any(Array) },
 		])
+	})
+})
+
+describe('create_sveltekit_config — unicorn/number-literal-case', () => {
+	it('aligns hex literal case with prettier (lowercase) to avoid eslint↔prettier fix loop', () => {
+		const config = build_config()
+
+		const block = find_block_with_rule(config, 'unicorn/number-literal-case')
+		const rules = block?.rules as Record<string, unknown>
+		const rule_value = rules['unicorn/number-literal-case'] as [
+			string,
+			{ hexadecimalValue: string },
+		]
+		const [, { hexadecimalValue: hexadecimal_value }] = rule_value
+
+		expect(hexadecimal_value).toBe('lowercase')
 	})
 })
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"version": "0.187.0",
+	"version": "0.188.0",
 	"name": "@joshuafolkken/kit",
 	"type": "module",
 	"license": "MIT",


### PR DESCRIPTION
closes #419