### PR TITLE
prefer-arrow-callback: add allowNamedFunctions to permit named function expressions #432

### DIFF
--- a/eslint/rules/code-quality.js
+++ b/eslint/rules/code-quality.js
@@ -9,8 +9,8 @@ export const code_quality_rules = {
 	'no-var': 'error',
 	// const を優先
 	'prefer-const': 'error',
-	// アロー関数を優先
-	'prefer-arrow-callback': 'error',
+	// アロー関数を優先（名前付き関数式はスタックトレース可読性のため許可）
+	'prefer-arrow-callback': ['error', { allowNamedFunctions: true }],
 	// テンプレートリテラルを優先
 	'prefer-template': 'error',
 	// 等価演算子は厳密等価を使用

--- a/eslint/rules/code-quality.test.ts
+++ b/eslint/rules/code-quality.test.ts
@@ -85,6 +85,28 @@ describe('code_quality_rules — id-length exceptions (issue #428 Gap 1)', () =>
 	})
 })
 
+interface PreferArrowCallbackOptions {
+	allowNamedFunctions: boolean
+}
+
+function get_prefer_arrow_callback_rule(): [string, PreferArrowCallbackOptions] {
+	return code_quality_rules['prefer-arrow-callback'] as [string, PreferArrowCallbackOptions]
+}
+
+describe('code_quality_rules — prefer-arrow-callback allowNamedFunctions (issue #432)', () => {
+	it('permits named function expressions via allowNamedFunctions', () => {
+		const [, options] = get_prefer_arrow_callback_rule()
+
+		expect(options.allowNamedFunctions).toBe(true)
+	})
+
+	it('still enforces the rule at error severity for anonymous callbacks', () => {
+		const [severity] = get_prefer_arrow_callback_rule()
+
+		expect(severity).toBe('error')
+	})
+})
+
 describe('code_quality_rules — id-length max (issue #428 Gap 2)', () => {
 	it('raises max to 45 so descriptive constant/function names are not penalized', () => {
 		const { max } = get_id_length_options()

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"version": "0.192.0",
+	"version": "0.193.0",
 	"name": "@joshuafolkken/kit",
 	"type": "module",
 	"license": "MIT",


### PR DESCRIPTION
closes #432