### PR TITLE
svelte override: disable sonarjs/no-use-of-empty-return-value for {@render snippet()} false positive #434

### DIFF
--- a/eslint/sveltekit.js
+++ b/eslint/sveltekit.js
@@ -76,6 +76,9 @@ export function create_sveltekit_config({ gitignore_path, tsconfig_root_dir, sve
 				],
 				'unicorn/prevent-abbreviations': ['error', { allowList: PREVENT_ABBR_ALLOW_LIST }],
 				'sonarjs/no-unused-collection': 'off',
+				// {@render snippet()} is a Svelte template directive, not a value-consuming
+				// expression; the rule misreads the void snippet call as a useless return value.
+				'sonarjs/no-use-of-empty-return-value': 'off',
 				...svelte_rules,
 			},
 		},

--- a/eslint/sveltekit.test.ts
+++ b/eslint/sveltekit.test.ts
@@ -166,6 +166,17 @@ describe('create_sveltekit_config — unicorn/number-literal-case', () => {
 	})
 })
 
+describe('create_sveltekit_config — sonarjs/no-use-of-empty-return-value (issue #434)', () => {
+	it('disables the rule in the svelte override for {@render snippet()} false positives', () => {
+		const config = build_config()
+
+		const svelte_block = find_svelte_files_block(config)
+		const rules = svelte_block?.rules as Record<string, unknown>
+
+		expect(rules['sonarjs/no-use-of-empty-return-value']).toBe('off')
+	})
+})
+
 describe('create_sveltekit_config — unicorn/prevent-abbreviations allowList', () => {
 	it('allows idiomatic short identifiers (e, el, ctx, btn, idx, opts, params, args) plus Props', () => {
 		const config = build_config()

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"version": "0.194.0",
+	"version": "0.195.0",
 	"name": "@joshuafolkken/kit",
 	"type": "module",
 	"license": "MIT",


### PR DESCRIPTION
closes #434