### PR TITLE
Move scripts-block ESLint overrides (no-os-command-from-path, unbound-method) into shared kit config #442

### DIFF
--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -5,6 +5,7 @@ words:
   - testuser
   - myorg
   - myrepo
+  - multicriteria
   - narratively
   - ncurc
   - unstub

--- a/eslint/base.js
+++ b/eslint/base.js
@@ -83,6 +83,11 @@ export function create_base_config({ gitignore_path, tsconfig_root_dir }) {
 			rules: {
 				'unicorn/no-process-exit': 'off',
 				'no-console': ['error', { allow: ['warn', 'error', 'info'] }],
+				// CLI tooling under scripts/ invokes pnpm/git/node via PATH by design
+				'sonarjs/no-os-command-from-path': 'off',
+				// kit's export { module } namespace pattern means functions never use this,
+				// so referencing them unbound (e.g. test spies) is safe
+				'@typescript-eslint/unbound-method': 'off',
 			},
 		},
 		{

--- a/eslint/base.test.ts
+++ b/eslint/base.test.ts
@@ -41,6 +41,29 @@ describe('create_base_config — scripts block', () => {
 	})
 })
 
+describe('create_base_config — scripts block (issue #442)', () => {
+	it('turns off no-os-command-from-path and unbound-method for scripts', () => {
+		const config = create_base_config({
+			gitignore_path: GITIGNORE_PATH,
+			tsconfig_root_dir: TSCONFIG_ROOT_DIR,
+		})
+
+		const scripts_block = config.find(
+			(block) =>
+				Array.isArray(block.files) &&
+				block.files.some((pattern) => String(pattern).startsWith('scripts/')) &&
+				typeof block.rules?.['unicorn/no-process-exit'] === 'string',
+		)
+
+		expect(scripts_block).toBeDefined()
+
+		const rules = scripts_block?.rules as Record<string, unknown>
+
+		expect(rules['sonarjs/no-os-command-from-path']).toBe('off')
+		expect(rules['@typescript-eslint/unbound-method']).toBe('off')
+	})
+})
+
 describe('create_base_config — tests block (issue #433)', () => {
 	it('disables unicorn/no-useless-undefined for vi mock/stub patterns', () => {
 		const config = create_base_config({

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"version": "0.197.0",
+	"version": "0.198.0",
 	"name": "@joshuafolkken/kit",
 	"type": "module",
 	"license": "MIT",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1392,8 +1392,8 @@ packages:
   devalue@5.8.1:
     resolution: {integrity: sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==}
 
-  electron-to-chromium@1.5.362:
-    resolution: {integrity: sha512-PUY2DrLvkjkUuWqq+KPL2iWshrJsZOcIojzRQ7eXFacc9dWga7MGMJAa15VbiejSZB1PAXaRLAiKgruHP8LB1w==}
+  electron-to-chromium@1.5.364:
+    resolution: {integrity: sha512-G/dYE3+AYhyHwzTwg8UbnXf7zqMERYh7l2jJ3QujhFsH8agSYwtnGAR2aZ7f0AakIKJXd5En/Hre4igIUrdlYw==}
 
   env-paths@4.0.0:
     resolution: {integrity: sha512-pxP8eL2SwwaTRi/KHYwLYXinDs7gL3jxFcBYmEdYfZmZXbaVDvdppd0XBU8qVz03rDfKZMXg1omHCbsJjZrMsw==}
@@ -3144,7 +3144,7 @@ snapshots:
     dependencies:
       baseline-browser-mapping: 2.10.32
       caniuse-lite: 1.0.30001793
-      electron-to-chromium: 1.5.362
+      electron-to-chromium: 1.5.364
       node-releases: 2.0.46
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
@@ -3297,7 +3297,7 @@ snapshots:
 
   devalue@5.8.1: {}
 
-  electron-to-chromium@1.5.362: {}
+  electron-to-chromium@1.5.364: {}
 
   env-paths@4.0.0:
     dependencies:

--- a/scripts-ai/issue-prep.ts
+++ b/scripts-ai/issue-prep.ts
@@ -18,7 +18,6 @@ function display_language_status(is_cjk: boolean): string {
 }
 
 function fetch_issue_title(number_string: string): string {
-	/* eslint-disable-next-line sonarjs/no-os-command-from-path */
 	return execFileSync('gh', ['issue', 'view', number_string, '--json', 'title', '--jq', '.title'], {
 		encoding: 'utf8',
 	}).trim()
@@ -67,7 +66,6 @@ function display_issue_info(
 function ensure_in_progress_label(): void {
 	try {
 		execFileSync(
-			/* eslint-disable-next-line sonarjs/no-os-command-from-path */
 			'gh',
 			[
 				'label',
@@ -86,7 +84,6 @@ function ensure_in_progress_label(): void {
 }
 
 function assign_in_progress_label(issue_number_string: string): void {
-	/* eslint-disable-next-line sonarjs/no-os-command-from-path */
 	execFileSync('gh', ['issue', 'edit', issue_number_string, '--add-label', IN_PROGRESS_LABEL], {
 		encoding: 'utf8',
 	})

--- a/scripts/fix-gh-packages.ts
+++ b/scripts/fix-gh-packages.ts
@@ -37,7 +37,6 @@ function read_file(file_path: string): string {
 
 function get_gh_cli_token(): string | undefined {
 	try {
-		// eslint-disable-next-line sonarjs/no-os-command-from-path -- trusted developer CLI; PATH is controlled by the developer
 		const token = execSync('gh auth token', { encoding: 'utf8', timeout: GH_CLI_TIMEOUT_MS }).trim()
 
 		return token.length > 0 ? token : undefined

--- a/scripts/gh-spawn.ts
+++ b/scripts/gh-spawn.ts
@@ -2,13 +2,11 @@ import { spawnSync } from 'node:child_process'
 import { PROJECT_ROOT } from './init-paths'
 
 function get_repo_name_with_owner(): string | undefined {
-	/* eslint-disable sonarjs/no-os-command-from-path */
 	const result = spawnSync(
 		'gh',
 		['repo', 'view', '--json', 'nameWithOwner', '--jq', '.nameWithOwner'],
 		{ encoding: 'utf8', cwd: PROJECT_ROOT },
 	)
-	/* eslint-enable sonarjs/no-os-command-from-path */
 	if (result.status !== 0 || !result.stdout) return undefined
 
 	return result.stdout.trim() || undefined

--- a/scripts/git/git-gh-exec.ts
+++ b/scripts/git/git-gh-exec.ts
@@ -33,7 +33,6 @@ function resolve_exit_code(code: number | null): string {
 function create_gh_spawn(
 	arguments_: Array<string>,
 ): ChildProcessByStdio<Writable, Readable, Readable> {
-	// eslint-disable-next-line sonarjs/no-os-command-from-path -- gh is a well-known CLI tool and safe to execute
 	return spawn('gh', arguments_, {
 		stdio: ['pipe', 'pipe', 'pipe'],
 		shell: false,

--- a/scripts/git/git-pr-checks-watch.ts
+++ b/scripts/git/git-pr-checks-watch.ts
@@ -57,7 +57,6 @@ function handle_watch_close(input: {
 
 async function pr_checks_watch(branch_name: string): Promise<WatchResult> {
 	return await new Promise<WatchResult>((resolve, reject) => {
-		// eslint-disable-next-line sonarjs/no-os-command-from-path -- gh is a well-known CLI tool and safe to execute
 		const child = spawn('gh', ['pr', 'checks', branch_name, '--watch'], {
 			stdio: 'inherit',
 			shell: false,

--- a/scripts/lint-parallel.ts
+++ b/scripts/lint-parallel.ts
@@ -16,7 +16,6 @@ interface LintCheckResult {
 async function run_process(arguments_: ReadonlyArray<string>): Promise<LintCheckResult> {
 	return await new Promise((resolve) => {
 		let output = ''
-		// eslint-disable-next-line sonarjs/no-os-command-from-path -- pnpm is a trusted developer CLI
 		const proc = spawn(PNPM, [...arguments_], {
 			stdio: 'pipe',
 			env: { ...process.env, FORCE_COLOR },

--- a/scripts/preinstall-version-update.ts
+++ b/scripts/preinstall-version-update.ts
@@ -15,7 +15,6 @@ function extract_pinned_version(preinstall: string): string | undefined {
 }
 
 function fetch_latest_version(): string | undefined {
-	// eslint-disable-next-line sonarjs/no-os-command-from-path -- npm is a well-known CLI tool
 	const result = spawnSync('npm', ['view', SAFE_CHAIN_PKG, 'version'], {
 		encoding: 'utf8',
 		shell: false,

--- a/scripts/sonar-config.test.ts
+++ b/scripts/sonar-config.test.ts
@@ -36,4 +36,17 @@ describe(SONAR_PROPERTIES_FILE, () => {
 	it('does not exclude scripts/ core package code from analysis', () => {
 		expect(exclusions).not.toContain('scripts/**')
 	})
+
+	it('suppresses the S4036 OS-command hotspot on scripts/ and scripts-ai/ via issue.ignore', () => {
+		const rule_keys = Object.entries(properties)
+			.filter(([key]) => key.endsWith('.ruleKey'))
+			.map(([, value]) => value)
+		const resource_keys = Object.entries(properties)
+			.filter(([key]) => key.endsWith('.resourceKey'))
+			.map(([, value]) => value)
+
+		expect(rule_keys).toContain('typescript:S4036')
+		expect(resource_keys).toContain('scripts/**/*')
+		expect(resource_keys).toContain('scripts-ai/**/*')
+	})
 })

--- a/scripts/version-check.ts
+++ b/scripts/version-check.ts
@@ -21,9 +21,7 @@ function read_current_version(): string {
 }
 
 function fetch_latest_version(): string {
-	/* eslint-disable sonarjs/no-os-command-from-path */
 	const output = execFileSync('gh', ['api', GH_API_PATH, '--jq', '.[0].name'])
-	/* eslint-enable sonarjs/no-os-command-from-path */
 
 	return output.toString().trim()
 }

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -15,6 +15,20 @@ sonar.coverage.exclusions=**/*
 # .claude/ hosts setup shell scripts synced from joshuafolkken/tasks (must not drift).
 sonar.exclusions=.claude/**
 
+# Suppress "OS command from PATH" hotspots (S4036) on dev/CLI tooling.
+# scripts/ and scripts-ai/ invoke pnpm/git/gh/node via PATH by design — trusted
+# developer CLIs, so S4036 is a known false-positive class here. The files stay
+# fully analyzed for every other rule (unlike sonar.exclusions, which drops them).
+sonar.issue.ignore.multicriteria=e1,e2,e3,e4
+sonar.issue.ignore.multicriteria.e1.ruleKey=typescript:S4036
+sonar.issue.ignore.multicriteria.e1.resourceKey=scripts/**/*
+sonar.issue.ignore.multicriteria.e2.ruleKey=typescript:S4036
+sonar.issue.ignore.multicriteria.e2.resourceKey=scripts-ai/**/*
+sonar.issue.ignore.multicriteria.e3.ruleKey=javascript:S4036
+sonar.issue.ignore.multicriteria.e3.resourceKey=scripts/**/*
+sonar.issue.ignore.multicriteria.e4.ruleKey=javascript:S4036
+sonar.issue.ignore.multicriteria.e4.resourceKey=scripts-ai/**/*
+
 # Files to exclude from the duplicate check
 sonar.cpd.exclusions=**/*.test.ts,**/*.spec.ts,**/*.e2e.ts
 

--- a/templates/sonar-project.properties
+++ b/templates/sonar-project.properties
@@ -16,6 +16,19 @@ sonar.coverage.exclusions=**/*
 # scripts/ hosts git / issue / overrides / telegram workflow tooling — not production code.
 sonar.exclusions=.claude/**,scripts/**
 
+# Suppress "OS command from PATH" hotspots (S4036) on dev/CLI tooling.
+# scripts/ is already fully excluded above; scripts-ai/ stays analyzed but invokes
+# pnpm/git/gh/node via PATH by design, so S4036 is a known false-positive class there.
+sonar.issue.ignore.multicriteria=e1,e2,e3,e4
+sonar.issue.ignore.multicriteria.e1.ruleKey=typescript:S4036
+sonar.issue.ignore.multicriteria.e1.resourceKey=scripts/**/*
+sonar.issue.ignore.multicriteria.e2.ruleKey=typescript:S4036
+sonar.issue.ignore.multicriteria.e2.resourceKey=scripts-ai/**/*
+sonar.issue.ignore.multicriteria.e3.ruleKey=javascript:S4036
+sonar.issue.ignore.multicriteria.e3.resourceKey=scripts/**/*
+sonar.issue.ignore.multicriteria.e4.ruleKey=javascript:S4036
+sonar.issue.ignore.multicriteria.e4.resourceKey=scripts-ai/**/*
+
 # Files to exclude from the duplicate check
 sonar.cpd.exclusions=**/*.test.ts,**/*.spec.ts,**/*.e2e.ts
 


### PR DESCRIPTION
closes #442