### PR TITLE
Guard templates against silent root drift with source-manifest parity #467

### DIFF
--- a/.template-source-manifest.json
+++ b/.template-source-manifest.json
@@ -1,0 +1,4 @@
+{
+	"sonar-project.properties": "aa9a22cf2ab9b65ea93d90bf11adf86b22a06c4ed94e0ec56632c967111af79e",
+	".gitignore": "79a6ebe115725737303d17639039871a0b6654e898bad012b50d9bb5892256c6"
+}

--- a/docs/josh-commands.md
+++ b/docs/josh-commands.md
@@ -219,6 +219,17 @@ Run a security audit against the lockfile.
 pnpm josh audit
 ```
 
+### `josh reconcile-templates`
+
+Record the current hashes of the root files that the distributed templates are derived from (`sonar-project.properties` → `templates/sonar-project.properties`, `.gitignore` → `templates/gitignore`). These templates are hand-maintained and intentionally diverge from kit's own root files, so they cannot be generated automatically.
+
+```bash
+pnpm josh reconcile-templates           # record current source hashes (acknowledge review)
+pnpm josh reconcile-templates --check    # verify no source drifted; non-zero on drift
+```
+
+The recorded hashes live in `.template-source-manifest.json` at the repo root (kit-internal; not distributed). A pre-commit hook runs `--check` whenever a tracked source is staged: if a source changed without being reconciled, the commit is blocked with a message pointing at the paired template to review. Whether the change should propagate to the template is a human decision — once reviewed, run `pnpm josh reconcile-templates` to acknowledge, then commit both the source and the updated manifest.
+
 ### `josh latest`
 
 Update pnpm via corepack, update all dependencies to latest, and run a security audit.

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,2 +1,12 @@
 extends:
   - ./lefthook/base.yml
+
+# Kit-internal only (this file is not distributed to consumers). Fires when a
+# tracked template source is staged, so a root edit cannot be committed without
+# the paired template being reviewed and the manifest reconciled.
+# Keep the glob in sync with TEMPLATE_SOURCE_PAIRS in scripts/template-source-logic.ts.
+pre-commit:
+  commands:
+    template-source-parity:
+      glob: '{sonar-project.properties,.gitignore}'
+      run: pnpm josh reconcile-templates --check

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"version": "0.210.0",
+	"version": "0.211.0",
 	"name": "@joshuafolkken/kit",
 	"type": "module",
 	"license": "MIT",

--- a/scripts/josh-command-map.ts
+++ b/scripts/josh-command-map.ts
@@ -58,6 +58,7 @@ const ALIASES: Record<string, string> = {
 	vu: 'version:upgrade',
 	ov: 'overrides',
 	a: 'audit',
+	rt: 'reconcile-templates',
 	u: 'latest',
 	lc: 'latest:corepack',
 	lu: 'latest:update',

--- a/scripts/josh-commands-maintenance.ts
+++ b/scripts/josh-commands-maintenance.ts
@@ -12,6 +12,11 @@ const MAINTENANCE_COMMANDS: Record<string, CommandEntry> = {
 		description: 'Run security audit',
 		category: 'Maintenance',
 	},
+	'reconcile-templates': {
+		script: 'scripts/reconcile-templates.ts',
+		description: 'Record template source hashes (--check to verify drift)',
+		category: 'Maintenance',
+	},
 	latest: {
 		shell: [
 			'sh',

--- a/scripts/reconcile-templates.ts
+++ b/scripts/reconcile-templates.ts
@@ -1,0 +1,49 @@
+#!/usr/bin/env tsx
+/**
+ * Reconcile (or check) the template source manifest.
+ *
+ * Usage:
+ *   tsx scripts/reconcile-templates.ts            # record current source hashes (acknowledge review)
+ *   tsx scripts/reconcile-templates.ts --check    # verify manifest matches sources; non-zero on drift
+ *
+ * A root source edit (sonar-project.properties / .gitignore) trips --check until
+ * the paired template is reviewed and the manifest is reconciled. Whether the
+ * change propagates to the template is a human decision; only the review is enforced.
+ */
+import { fileURLToPath } from 'node:url'
+import { parseArgs } from 'node:util'
+import { template_source_logic } from './template-source-logic'
+
+function check_drift(): never {
+	const recorded = template_source_logic.read_recorded_manifest()
+	const current = template_source_logic.compute_current_manifest()
+	const drifted = template_source_logic.find_drifted_pairs(recorded, current)
+
+	if (drifted.length > 0) {
+		console.error(template_source_logic.format_drift_message(drifted))
+		process.exit(1)
+	}
+
+	console.info('✔ Template sources unchanged since last reconciled.')
+	process.exit(0)
+}
+
+function reconcile(): never {
+	template_source_logic.write_recorded_manifest(template_source_logic.compute_current_manifest())
+	console.info(`✔ Template source manifest reconciled (${template_source_logic.MANIFEST_PATH}).`)
+	process.exit(0)
+}
+
+function main(): void {
+	const { values } = parseArgs({
+		options: { check: { type: 'boolean', default: false } },
+		strict: true,
+	})
+
+	if (values.check) check_drift()
+	reconcile()
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) main()
+
+export { check_drift, reconcile }

--- a/scripts/template-source-logic.test.ts
+++ b/scripts/template-source-logic.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest'
+import {
+	template_source_logic,
+	type SourceManifest,
+	type TemplateSourcePair,
+} from './template-source-logic'
+
+const { hash_text, build_manifest, find_drifted_pairs, format_drift_message } =
+	template_source_logic
+const TRACKED_PAIRS: ReadonlyArray<TemplateSourcePair> = template_source_logic.TEMPLATE_SOURCE_PAIRS
+
+// Build a manifest keyed by the real tracked sources, one hash per source, so
+// tests never need dotted object-literal keys (which violate naming-convention).
+function manifest_from(hashes: ReadonlyArray<string>): SourceManifest {
+	const manifest: SourceManifest = {}
+
+	for (const [index, pair] of TRACKED_PAIRS.entries()) {
+		manifest[pair.source] = hashes[index] ?? ''
+	}
+
+	return manifest
+}
+
+function first_pair(): TemplateSourcePair {
+	const [pair] = TRACKED_PAIRS
+	if (!pair) throw new Error('TEMPLATE_SOURCE_PAIRS must not be empty')
+
+	return pair
+}
+
+describe('template_source_logic.hash_text', () => {
+	it('is deterministic for the same input', () => {
+		expect(hash_text('abc')).toBe(hash_text('abc'))
+	})
+
+	it('changes when the input changes', () => {
+		expect(hash_text('abc')).not.toBe(hash_text('abcd'))
+	})
+})
+
+describe('template_source_logic.build_manifest', () => {
+	it('maps each source to the hash of its content', () => {
+		const manifest = build_manifest(manifest_from(['node_modules\n']))
+
+		expect(manifest[first_pair().source]).toBe(hash_text('node_modules\n'))
+	})
+})
+
+describe('template_source_logic.find_drifted_pairs', () => {
+	it('returns nothing when recorded and current hashes match', () => {
+		const current = manifest_from(['x', 'y'])
+
+		expect(find_drifted_pairs(current, current)).toEqual([])
+	})
+
+	it('returns only the pair whose source hash diverged', () => {
+		const recorded = manifest_from(['x', 'y'])
+		const current = manifest_from(['CHANGED', 'y'])
+		const drifted = find_drifted_pairs(recorded, current)
+
+		expect(drifted.map((pair) => pair.source)).toEqual([first_pair().source])
+	})
+
+	it('treats a source missing from the recorded manifest as drift', () => {
+		const current = manifest_from(['x', 'y'])
+
+		expect(find_drifted_pairs({}, current)).toHaveLength(TRACKED_PAIRS.length)
+	})
+})
+
+describe('template_source_logic.format_drift_message', () => {
+	it('names each drifted source and its paired template', () => {
+		const pair = first_pair()
+		const message = format_drift_message([pair])
+
+		expect(message).toContain(`${pair.source} changed → review ${pair.template}`)
+		expect(message).toContain('pnpm josh reconcile-templates')
+	})
+})

--- a/scripts/template-source-logic.ts
+++ b/scripts/template-source-logic.ts
@@ -1,0 +1,100 @@
+import { createHash } from 'node:crypto'
+import { readFileSync, writeFileSync } from 'node:fs'
+import { z } from 'zod'
+import { package_path } from './init-paths'
+
+interface TemplateSourcePair {
+	template: string
+	source: string
+}
+
+// Internal maintainer guard state. Kept at the repo root (not under templates/)
+// so it is NOT distributed to consumers via the package `files` field, matching
+// the .overrides-snapshot.json convention.
+const MANIFEST_PATH = '.template-source-manifest.json'
+
+// Each template is hand-maintained and intentionally diverges from its root
+// source (half of past source edits were deliberately not propagated). The
+// manifest records the source hash last reviewed, so any later edit to a source
+// trips the guard and forces a conscious re-check of the paired template.
+// Propagation stays a human decision; only the review is enforced.
+//
+// When adding a pair here, also add its `source` to the `template-source-parity`
+// glob in lefthook.yml so the pre-commit guard fires for it (CI's parity test
+// covers every pair regardless).
+const TEMPLATE_SOURCE_PAIRS: ReadonlyArray<TemplateSourcePair> = [
+	{ template: 'templates/sonar-project.properties', source: 'sonar-project.properties' },
+	{ template: 'templates/gitignore', source: '.gitignore' },
+]
+
+const source_manifest_schema = z.record(z.string(), z.string())
+
+type SourceManifest = z.infer<typeof source_manifest_schema>
+
+function hash_text(text: string): string {
+	return createHash('sha256').update(text).digest('hex')
+}
+
+function build_manifest(source_contents: SourceManifest): SourceManifest {
+	const manifest: SourceManifest = {}
+
+	for (const [source, content] of Object.entries(source_contents)) {
+		manifest[source] = hash_text(content)
+	}
+
+	return manifest
+}
+
+function find_drifted_pairs(
+	recorded: SourceManifest,
+	current: SourceManifest,
+): Array<TemplateSourcePair> {
+	return TEMPLATE_SOURCE_PAIRS.filter((pair) => recorded[pair.source] !== current[pair.source])
+}
+
+function format_drift_message(drifted: ReadonlyArray<TemplateSourcePair>): string {
+	const lines = drifted.map((pair) => `  - ${pair.source} changed → review ${pair.template}`)
+
+	return [
+		'✖ Template source(s) changed since last reconciled:',
+		...lines,
+		'  Review each paired template, then run `pnpm josh reconcile-templates` to acknowledge.',
+	].join('\n')
+}
+
+function read_source_contents(): SourceManifest {
+	const contents: SourceManifest = {}
+
+	for (const pair of TEMPLATE_SOURCE_PAIRS) {
+		contents[pair.source] = readFileSync(package_path(pair.source), 'utf8')
+	}
+
+	return contents
+}
+
+function compute_current_manifest(): SourceManifest {
+	return build_manifest(read_source_contents())
+}
+
+function read_recorded_manifest(): SourceManifest {
+	return source_manifest_schema.parse(JSON.parse(readFileSync(package_path(MANIFEST_PATH), 'utf8')))
+}
+
+function write_recorded_manifest(manifest: SourceManifest): void {
+	writeFileSync(package_path(MANIFEST_PATH), `${JSON.stringify(manifest, undefined, '\t')}\n`)
+}
+
+const template_source_logic = {
+	MANIFEST_PATH,
+	TEMPLATE_SOURCE_PAIRS,
+	hash_text,
+	build_manifest,
+	find_drifted_pairs,
+	format_drift_message,
+	compute_current_manifest,
+	read_recorded_manifest,
+	write_recorded_manifest,
+}
+
+export { template_source_logic, source_manifest_schema }
+export type { SourceManifest, TemplateSourcePair }

--- a/scripts/template-source-parity.test.ts
+++ b/scripts/template-source-parity.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import { template_source_logic } from './template-source-logic'
+
+// Co-change tripwire: if a root source (sonar-project.properties / .gitignore)
+// is edited without reconciling the manifest, this test fails and points at the
+// paired template that must be reviewed. Run `pnpm josh reconcile-templates`
+// after reviewing to acknowledge.
+describe('template source parity', () => {
+	it('every recorded source hash matches the current source file', () => {
+		const recorded = template_source_logic.read_recorded_manifest()
+		const current = template_source_logic.compute_current_manifest()
+		const drifted = template_source_logic.find_drifted_pairs(recorded, current)
+
+		expect(drifted, template_source_logic.format_drift_message(drifted)).toEqual([])
+	})
+
+	it('records a hash for every tracked template source', () => {
+		const recorded = template_source_logic.read_recorded_manifest()
+		const tracked_sources = template_source_logic.TEMPLATE_SOURCE_PAIRS.map((pair) => pair.source)
+
+		for (const source of tracked_sources) expect(recorded, source).toHaveProperty([source])
+	})
+})


### PR DESCRIPTION
closes #467