### PR TITLE
Remove deprecated svelteStrictMode from the shared Prettier config #476

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"version": "0.214.0",
+	"version": "0.215.0",
 	"name": "@joshuafolkken/kit",
 	"type": "module",
 	"license": "MIT",

--- a/prettier/index.js
+++ b/prettier/index.js
@@ -17,7 +17,6 @@ export const config = {
 			files: '*.svelte',
 			options: {
 				parser: 'svelte',
-				svelteStrictMode: true,
 				svelteIndentScriptAndStyle: true,
 				svelteSortOrder: 'options-scripts-markup-styles',
 			},

--- a/prettier/index.test.ts
+++ b/prettier/index.test.ts
@@ -1,0 +1,38 @@
+import type { Options } from 'prettier'
+import { describe, expect, it } from 'vitest'
+import { config } from './index.js'
+
+// prettier-plugin-svelte v4 removed these options; keeping them triggers
+// "Ignored unknown option { ... }" warnings on every .svelte file.
+const REMOVED_SVELTE_OPTIONS = ['svelteStrictMode', 'svelteBracketNewLine']
+
+// Options that are still valid in prettier-plugin-svelte v4 and must remain.
+const REQUIRED_SVELTE_OPTIONS = ['svelteIndentScriptAndStyle', 'svelteSortOrder']
+
+function find_svelte_override(): Options {
+	const override = config.overrides?.find((entry) => entry.files === '*.svelte')
+
+	if (!override) throw new Error('Expected a *.svelte override in the Prettier config')
+
+	return override.options
+}
+
+describe('shared Prettier config — *.svelte override', () => {
+	it('does not set any prettier-plugin-svelte v4 removed options', () => {
+		const options = find_svelte_override() as Record<string, unknown>
+
+		for (const removed of REMOVED_SVELTE_OPTIONS) {
+			expect(options).not.toHaveProperty(removed)
+		}
+	})
+
+	it('keeps the svelte options still supported in v4', () => {
+		const options = find_svelte_override() as Record<string, unknown>
+
+		expect(options.parser).toBe('svelte')
+
+		for (const required of REQUIRED_SVELTE_OPTIONS) {
+			expect(options).toHaveProperty(required)
+		}
+	})
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
 			'scripts/**/*.test.ts',
 			'scripts-ai/**/*.test.ts',
 			'eslint/**/*.test.ts',
+			'prettier/**/*.test.ts',
 			'templates/**/*.test.ts',
 		],
 		testTimeout: TEST_TIMEOUT_MS,


### PR DESCRIPTION
closes #476