### PR TITLE
Auto-align devEngines.packageManager.version with packageManager across latest:corepack / init / sync #480

### DIFF
--- a/docs/josh-commands.md
+++ b/docs/josh-commands.md
@@ -95,7 +95,7 @@ Overwrite managed files with the latest versions from the package.
 pnpm josh sync
 ```
 
-Run after upgrading `@joshuafolkken/kit` to pull in updated AI files, GitHub workflow templates, and other managed files. See [sync.md](./sync.md) for the full list.
+Run after upgrading `@joshuafolkken/kit` to pull in updated AI files, GitHub workflow templates, and other managed files. See [sync.md](./sync.md) for the full list. `sync` also realigns `devEngines.packageManager.version` in `package.json` with the `packageManager` pin so the two never drift apart (a mismatch reintroduces the pnpm `Cannot use both "packageManager" and "devEngines.packageManager"` warning).
 
 > To make `josh` available system-wide, install the kit globally (`pnpm add -g @joshuafolkken/kit`) instead of running an install subcommand. See [cli.md](./cli.md) for details.
 
@@ -243,7 +243,7 @@ pnpm josh latest:corepack   # update pnpm only
 pnpm josh latest:update     # update dependencies only
 ```
 
-`latest:corepack` pins pnpm to the newest release on the project's **current major** (`latest-<major>`, derived from `packageManager`; it falls back to `pnpm@latest` only if that major can't be parsed), so on the normal path it stays within `devEngines`. If the selected release is still inside the registry's minimum-release-age window, the pnpm bump is skipped with a notice instead of failing — so `latest:update` and `audit` still run.
+`latest:corepack` pins pnpm to the newest release on the project's **current major** (`latest-<major>`, derived from `packageManager`; it falls back to `pnpm@latest` only if that major can't be parsed), so on the normal path it stays within `devEngines`. If the selected release is still inside the registry's minimum-release-age window, the pnpm bump is skipped with a notice instead of failing — so `latest:update` and `audit` still run. When the bump does succeed, `devEngines.packageManager.version` is realigned to the new `packageManager` pin so the two stay in exact match (avoiding the pnpm dual-declaration warning).
 
 ---
 

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -78,7 +78,7 @@ This transformation is applied to backtick-quoted paths matching the pattern `` 
 
 ## What does NOT get synced
 
-- `package.json` — intentionally init-only to avoid clobbering project version / dependencies. To refresh kit-managed scripts or dev-dependency pins, re-run `josh init`.
+- `package.json` — largely init-only to avoid clobbering project version / dependencies. To refresh kit-managed scripts or dev-dependency pins, re-run `josh init`. The one exception: `sync` realigns `devEngines.packageManager.version` with the `packageManager` pin (a drift between the two reintroduces the pnpm `Cannot use both "packageManager" and "devEngines.packageManager"` warning); scripts, dependencies, and the project version are never touched.
 
 ## When to run
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"version": "0.216.0",
+	"version": "0.217.0",
 	"name": "@joshuafolkken/kit",
 	"type": "module",
 	"license": "MIT",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2128,8 +2128,8 @@ packages:
     resolution: {integrity: sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==}
     engines: {node: '>=14.16'}
 
-  svelte-eslint-parser@1.7.0:
-    resolution: {integrity: sha512-TU3DQx7IjUrrxKbET/U639xofp044xLXGGvFaLH9PKQOY5g5iRtmYy2rZB7gOeGRRTP7255AE8fUtIwsp/yOjQ==}
+  svelte-eslint-parser@1.7.1:
+    resolution: {integrity: sha512-mmwwKL9L/MB0QyBKdfyWxGjDuQfEyzxWy5S9Kkd0O/V5XD57MQ33KQtXrO6vKLuP6PIt8CRozvOX1mxpcRTqUg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0, pnpm: 10.34.1}
     peerDependencies:
       svelte: ^5.55.7
@@ -3420,7 +3420,7 @@ snapshots:
       postcss-load-config: 3.1.4(postcss@8.5.15)
       postcss-safe-parser: 7.0.1(postcss@8.5.15)
       semver: 7.8.1
-      svelte-eslint-parser: 1.7.0(svelte@5.55.7(@typescript-eslint/types@8.60.0))
+      svelte-eslint-parser: 1.7.1(svelte@5.55.7(@typescript-eslint/types@8.60.0))
     optionalDependencies:
       svelte: 5.55.7(@typescript-eslint/types@8.60.0)
     transitivePeerDependencies:
@@ -3931,7 +3931,7 @@ snapshots:
 
   strip-json-comments@5.0.3: {}
 
-  svelte-eslint-parser@1.7.0(svelte@5.55.7(@typescript-eslint/types@8.60.0)):
+  svelte-eslint-parser@1.7.1(svelte@5.55.7(@typescript-eslint/types@8.60.0)):
     dependencies:
       eslint-scope: 8.4.0
       eslint-visitor-keys: 4.2.1

--- a/scripts/init-package-manager-align.test.ts
+++ b/scripts/init-package-manager-align.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { init } from './init'
+import { package_manager_version } from './package-manager-version'
+
+interface PackageJson {
+	packageManager: string
+	devEngines: { packageManager: { version: string } }
+}
+
+// A consumer manifest that already pins packageManager but carries a drifted
+// (range) devEngines version, mirroring a project scaffolded before the
+// exact-match policy. `apply_package_json_merges` must leave the consumer's own
+// packageManager intact and realign devEngines to it.
+const CONSUMER_WITH_DRIFT =
+	`{\n\t"name": "demo",\n\t"packageManager": "pnpm@11.4.0+sha512.abc",\n` +
+	`\t"devEngines": {\n\t\t"packageManager": {\n\t\t\t"name": "pnpm",\n` +
+	`\t\t\t"version": ">=11.0.0-0",\n\t\t\t"onFail": "error"\n\t\t}\n\t}\n}\n`
+
+describe('init.apply_package_json_merges devEngines alignment', () => {
+	it('aligns devEngines.packageManager.version with the consumer packageManager pin', () => {
+		const result = init.apply_package_json_merges(CONSUMER_WITH_DRIFT, 'vanilla')
+		const parsed = JSON.parse(result) as PackageJson
+		const pin = package_manager_version.extract_pnpm_version(parsed.packageManager)
+
+		expect(pin).toBe('11.4.0')
+		expect(parsed.devEngines.packageManager.version).toBe('11.4.0')
+	})
+})

--- a/scripts/init.ts
+++ b/scripts/init.ts
@@ -7,6 +7,7 @@ import { fileURLToPath } from 'node:url'
 import { init_ai_copy } from './init-ai-copy'
 import { init_logic, type ProjectType } from './init-logic'
 import { is_sveltekit_project, package_path, PROJECT_ROOT } from './init-paths'
+import { package_manager_version } from './package-manager-version'
 import { string_array_schema, vscode_settings_schema, with_package_manager_schema } from './schemas'
 import { sync } from './sync'
 
@@ -243,8 +244,12 @@ function apply_package_json_merges(content: string, type: ProjectType): string {
 	const with_pm =
 		kit_pm === undefined ? with_lifecycle : init_logic.merge_package_manager(with_lifecycle, kit_pm)
 	const with_de = init_logic.merge_development_engines(with_pm, get_kit_development_engines())
+	const sorted = init_logic.sort_package_json_keys(with_de)
 
-	return init_logic.sort_package_json_keys(with_de)
+	// Pin devEngines.packageManager.version to the packageManager just written so a
+	// freshly scaffolded (or re-initialized) consumer never trips the pnpm
+	// dual-declaration warning.
+	return package_manager_version.align_development_engines_version(sorted)
 }
 
 function merge_project_package_json(type: ProjectType): void {
@@ -305,6 +310,7 @@ if (process.argv[1] === fileURLToPath(import.meta.url)) await main()
 
 const init = {
 	copy_ai_file: init_ai_copy.copy_ai_file,
+	apply_package_json_merges,
 }
 
 export { init }

--- a/scripts/latest-corepack.ts
+++ b/scripts/latest-corepack.ts
@@ -22,8 +22,9 @@
  * Usage: tsx scripts/latest-corepack.ts
  */
 import { spawnSync } from 'node:child_process'
-import { readFileSync } from 'node:fs'
+import { readFileSync, writeFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
+import { package_manager_version } from './package-manager-version'
 
 const PACKAGE_JSON_PATH = 'package.json'
 const PACKAGE_MANAGER_RE = /"packageManager"\s*:\s*"pnpm@(\d+)(?:[^\d]|$)/u
@@ -61,10 +62,22 @@ function warn_if_skipped(status: number): boolean {
 	return true
 }
 
+// After corepack bumps the `packageManager` pin, realign
+// `devEngines.packageManager.version` to the new version so the two fields keep
+// matching (pnpm suppresses the dual-declaration warning only on an exact match).
+function sync_development_engines_after_bump(package_json_path: string = PACKAGE_JSON_PATH): void {
+	const content = readFileSync(package_json_path, 'utf8')
+	const aligned = package_manager_version.align_development_engines_version(content)
+	if (aligned === content) return
+
+	writeFileSync(package_json_path, aligned)
+	console.info('✔ Synced devEngines.packageManager.version to the packageManager pin')
+}
+
 function main(): void {
 	const target = resolve_corepack_target(readFileSync(PACKAGE_JSON_PATH, 'utf8'))
-
-	warn_if_skipped(run_corepack(target))
+	const is_skipped = warn_if_skipped(run_corepack(target))
+	if (!is_skipped) sync_development_engines_after_bump()
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) main()
@@ -75,6 +88,7 @@ const latest_corepack = {
 	resolve_corepack_target,
 	run_corepack,
 	warn_if_skipped,
+	sync_development_engines_after_bump,
 	main,
 }
 

--- a/scripts/package-manager-version-consistency.test.ts
+++ b/scripts/package-manager-version-consistency.test.ts
@@ -2,12 +2,9 @@ import { readFileSync } from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
+import { package_manager_version } from './package-manager-version'
 
 const PACKAGE_ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), '..')
-// Capture the full version (including any prerelease identifier) up to the
-// optional `+<hash>` suffix, so prerelease pins like `pnpm@11.6.0-rc.1+...` are
-// compared faithfully rather than truncated to `11.6.0`.
-const PNPM_VERSION_REGEX = /^pnpm@([^+]+)/u
 
 interface PackageJson {
 	packageManager: string
@@ -24,9 +21,11 @@ const PACKAGE_JSON = JSON.parse(
 // If a future bump drifts one field, this fails before the warning reappears.
 describe('package.json packageManager / devEngines version consistency', () => {
 	it('pins devEngines.packageManager.version to the exact packageManager version', () => {
-		const package_manager_version = PNPM_VERSION_REGEX.exec(PACKAGE_JSON.packageManager)?.[1]
+		const package_manager_pin = package_manager_version.extract_pnpm_version(
+			PACKAGE_JSON.packageManager,
+		)
 
-		expect(package_manager_version).toBeDefined()
-		expect(PACKAGE_JSON.devEngines.packageManager.version).toBe(package_manager_version)
+		expect(package_manager_pin).toBeDefined()
+		expect(PACKAGE_JSON.devEngines.packageManager.version).toBe(package_manager_pin)
 	})
 })

--- a/scripts/package-manager-version-sync.test.ts
+++ b/scripts/package-manager-version-sync.test.ts
@@ -1,0 +1,65 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { latest_corepack } from './latest-corepack'
+import { sync } from './sync'
+
+const DRIFTED = `{\n\t"name": "demo",\n\t"packageManager": "pnpm@11.5.0+sha512.abc",\n\t"devEngines": {\n\t\t"packageManager": {\n\t\t\t"name": "pnpm",\n\t\t\t"version": ">=11.0.0-0",\n\t\t\t"onFail": "error"\n\t\t}\n\t}\n}\n`
+const ALIGNED = DRIFTED.replace('>=11.0.0-0', '11.5.0')
+
+let work_directory = ''
+let package_json_path = ''
+
+function read_manifest(): string {
+	return readFileSync(package_json_path, 'utf8')
+}
+
+beforeEach(() => {
+	work_directory = mkdtempSync(path.join(tmpdir(), 'pm-version-sync-'))
+	package_json_path = path.join(work_directory, 'package.json')
+	vi.spyOn(console, 'info').mockImplementation(() => undefined)
+})
+
+afterEach(() => {
+	rmSync(work_directory, { recursive: true, force: true })
+	vi.restoreAllMocks()
+})
+
+describe('sync.sync_package_manager_version', () => {
+	it('repairs a drifted devEngines version to match the packageManager pin', () => {
+		writeFileSync(package_json_path, DRIFTED)
+		sync.sync_package_manager_version(package_json_path)
+
+		expect(read_manifest()).toBe(ALIGNED)
+	})
+
+	it('leaves an already-aligned manifest untouched during sync', () => {
+		writeFileSync(package_json_path, ALIGNED)
+		sync.sync_package_manager_version(package_json_path)
+
+		expect(read_manifest()).toBe(ALIGNED)
+	})
+
+	it('does nothing when the manifest is missing', () => {
+		expect(() => {
+			sync.sync_package_manager_version(package_json_path)
+		}).not.toThrow()
+	})
+})
+
+describe('latest_corepack.sync_development_engines_after_bump', () => {
+	it('rewrites a drifted devEngines version to the packageManager pin', () => {
+		writeFileSync(package_json_path, DRIFTED)
+		latest_corepack.sync_development_engines_after_bump(package_json_path)
+
+		expect(read_manifest()).toBe(ALIGNED)
+	})
+
+	it('leaves an already-aligned manifest untouched after a bump', () => {
+		writeFileSync(package_json_path, ALIGNED)
+		latest_corepack.sync_development_engines_after_bump(package_json_path)
+
+		expect(read_manifest()).toBe(ALIGNED)
+	})
+})

--- a/scripts/package-manager-version.test.ts
+++ b/scripts/package-manager-version.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest'
+import { package_manager_version } from './package-manager-version'
+
+const PM_PIN = 'pnpm@11.5.0+sha512.abc'
+const PM_PRERELEASE_PIN = 'pnpm@11.6.0-rc.1+sha512.def'
+const RANGE_VERSION = '>=11.0.0-0'
+const EXACT_VERSION = '11.5.0'
+const PRERELEASE_VERSION = '11.6.0-rc.1'
+
+function build_manifest(
+	package_manager: string | undefined,
+	development_engines_version: string,
+): string {
+	const package_manager_line =
+		package_manager === undefined ? '' : `\t"packageManager": "${package_manager}",\n`
+
+	return `{\n\t"name": "demo",\n${package_manager_line}\t"devEngines": {\n\t\t"packageManager": {\n\t\t\t"name": "pnpm",\n\t\t\t"version": "${development_engines_version}",\n\t\t\t"onFail": "error"\n\t\t}\n\t}\n}\n`
+}
+
+const align = package_manager_version.align_development_engines_version
+
+describe('package_manager_version.extract_pnpm_version', () => {
+	it('extracts the version from a hash-suffixed pin', () => {
+		expect(package_manager_version.extract_pnpm_version(PM_PIN)).toBe(EXACT_VERSION)
+	})
+
+	it('preserves a prerelease identifier rather than truncating it', () => {
+		expect(package_manager_version.extract_pnpm_version(PM_PRERELEASE_PIN)).toBe(PRERELEASE_VERSION)
+	})
+
+	it('extracts the version from a bare pin without a hash', () => {
+		expect(package_manager_version.extract_pnpm_version('pnpm@11.5.0')).toBe(EXACT_VERSION)
+	})
+
+	it('returns undefined for a non-pnpm package manager', () => {
+		expect(package_manager_version.extract_pnpm_version('yarn@4.0.0')).toBeUndefined()
+	})
+
+	it('returns undefined for an empty value', () => {
+		expect(package_manager_version.extract_pnpm_version('')).toBeUndefined()
+	})
+})
+
+describe('package_manager_version.align_development_engines_version — rewrites', () => {
+	it('rewrites a drifted devEngines version to match the packageManager pin', () => {
+		expect(align(build_manifest(PM_PIN, RANGE_VERSION))).toBe(build_manifest(PM_PIN, EXACT_VERSION))
+	})
+
+	it('aligns to a prerelease version faithfully', () => {
+		expect(align(build_manifest(PM_PRERELEASE_PIN, EXACT_VERSION))).toBe(
+			build_manifest(PM_PRERELEASE_PIN, PRERELEASE_VERSION),
+		)
+	})
+
+	it('aligns when devEngines lists version before name', () => {
+		const version_first = `{\n\t"packageManager": "${PM_PIN}",\n\t"devEngines": { "packageManager": { "version": "${RANGE_VERSION}", "name": "pnpm" } }\n}\n`
+		const expected = `{\n\t"packageManager": "${PM_PIN}",\n\t"devEngines": { "packageManager": { "version": "${EXACT_VERSION}", "name": "pnpm" } }\n}\n`
+
+		expect(align(version_first)).toBe(expected)
+	})
+})
+
+describe('package_manager_version.align_development_engines_version — no-ops', () => {
+	it('leaves the content untouched when the versions already match', () => {
+		const matched = build_manifest(PM_PIN, EXACT_VERSION)
+
+		expect(align(matched)).toBe(matched)
+	})
+
+	it('leaves the content untouched when packageManager is absent', () => {
+		const without_pm = build_manifest(undefined, RANGE_VERSION)
+
+		expect(align(without_pm)).toBe(without_pm)
+	})
+
+	it('leaves the content untouched when devEngines.packageManager is absent', () => {
+		const without_development_engines = `{\n\t"name": "demo",\n\t"packageManager": "${PM_PIN}"\n}\n`
+
+		expect(align(without_development_engines)).toBe(without_development_engines)
+	})
+})

--- a/scripts/package-manager-version.ts
+++ b/scripts/package-manager-version.ts
@@ -1,0 +1,74 @@
+import { z } from 'zod'
+
+// Capture the full version (including any prerelease identifier) up to the
+// optional `+<hash>` suffix, so prerelease pins like `pnpm@11.6.0-rc.1+...` are
+// read faithfully rather than truncated to `11.6.0`.
+const PNPM_VERSION_REGEX = /^pnpm@([^+]+)/u
+
+// Surgical replacements that touch only the `devEngines.packageManager.version`
+// value, preserving the rest of the file's formatting byte-for-byte. Two key
+// orders are supported because a hand-edited consumer manifest may list either
+// `name` or `version` first.
+const DEV_ENGINES_NAME_FIRST_REGEX = /("name":\s*"pnpm"\s*,\s*"version":\s*")[^"]+(")/u
+const DEV_ENGINES_VERSION_FIRST_REGEX = /("version":\s*")[^"]+("\s*,\s*"name":\s*"pnpm")/u
+
+const alignment_read_schema = z.object({
+	packageManager: z.string().optional(),
+	devEngines: z
+		.object({
+			packageManager: z.object({ version: z.string().optional() }).optional(),
+		})
+		.optional(),
+})
+
+type AlignmentManifest = z.infer<typeof alignment_read_schema>
+
+function extract_pnpm_version(package_manager: string): string | undefined {
+	return PNPM_VERSION_REGEX.exec(package_manager)?.[1]
+}
+
+function read_current_version(parsed: AlignmentManifest): string | undefined {
+	return parsed.devEngines?.packageManager?.version
+}
+
+// Return the version that `devEngines.packageManager.version` should adopt, or
+// undefined when there is nothing to align: no `packageManager`, no existing
+// `devEngines.packageManager`, or the two already match.
+function resolve_alignment_target(parsed: AlignmentManifest): string | undefined {
+	if (parsed.packageManager === undefined) return undefined
+	const target = extract_pnpm_version(parsed.packageManager)
+	const current = read_current_version(parsed)
+	if (current === undefined || current === target) return undefined
+
+	return target
+}
+
+function replace_development_engines_version(content: string, target: string): string {
+	if (DEV_ENGINES_NAME_FIRST_REGEX.test(content)) {
+		return content.replace(DEV_ENGINES_NAME_FIRST_REGEX, `$1${target}$2`)
+	}
+
+	if (DEV_ENGINES_VERSION_FIRST_REGEX.test(content)) {
+		return content.replace(DEV_ENGINES_VERSION_FIRST_REGEX, `$1${target}$2`)
+	}
+
+	return content
+}
+
+// Align `devEngines.packageManager.version` with the version pinned in the
+// `packageManager` field so pnpm 11.5.0+ (pnpm/pnpm#11307) suppresses the
+// "Cannot use both ..." warning.
+function align_development_engines_version(content: string): string {
+	const parsed = alignment_read_schema.parse(JSON.parse(content))
+	const target = resolve_alignment_target(parsed)
+	if (target === undefined) return content
+
+	return replace_development_engines_version(content, target)
+}
+
+const package_manager_version = {
+	extract_pnpm_version,
+	align_development_engines_version,
+}
+
+export { package_manager_version }

--- a/scripts/sync.ts
+++ b/scripts/sync.ts
@@ -5,11 +5,13 @@ import { fileURLToPath } from 'node:url'
 import { gh_spawn } from './gh-spawn'
 import { init_logic, type ProjectType } from './init-logic'
 import { is_sveltekit_project, PACKAGE_DIR, PROJECT_ROOT } from './init-paths'
+import { package_manager_version } from './package-manager-version'
 import { sonar_file } from './sonar-file'
 import { sync_configs } from './sync-configs'
 
 const WORKSPACE_YAML = 'pnpm-workspace.yaml'
 const WRANGLER_JSONC = 'wrangler.jsonc'
+const PACKAGE_JSON = 'package.json'
 
 function sync_ai_file(source_path: string, destination_path: string): void {
 	mkdirSync(path.dirname(destination_path), { recursive: true })
@@ -212,8 +214,37 @@ function sync_config_files(type: ProjectType): void {
 	}
 }
 
+// Repair an existing consumer manifest whose devEngines.packageManager.version
+// has drifted from its packageManager pin, so the pnpm dual-declaration warning
+// stays suppressed.
+function sync_package_manager_version(destination_path: string): void {
+	if (!existsSync(destination_path)) return
+
+	const existing = readFileSync(destination_path, 'utf8')
+	const aligned = package_manager_version.align_development_engines_version(existing)
+
+	if (aligned === existing) {
+		console.info('  ✔ unchanged package.json')
+
+		return
+	}
+
+	writeFileSync(destination_path, aligned)
+	console.info('  ✔ synced    devEngines.packageManager.version')
+}
+
 function resolve_project_type(): ProjectType {
 	return is_sveltekit_project(PROJECT_ROOT) ? 'sveltekit' : 'vanilla'
+}
+
+function sync_project_artifacts(type: ProjectType, is_force: boolean): void {
+	sync_ai_copy_all(is_force)
+	sync_prettier_config(path.join(PROJECT_ROOT, 'prettier.config.js'))
+	sync_playwright_config(path.join(PROJECT_ROOT, 'playwright.config.ts'))
+	sync_deploy_vps(path.join(PROJECT_ROOT, '.github/workflows/deploy-vps.yml'))
+	sync_sonar_with_template(is_force)
+	sync_config_files(type)
+	sync_package_manager_version(path.join(PROJECT_ROOT, PACKAGE_JSON))
 }
 
 function main(): void {
@@ -221,12 +252,7 @@ function main(): void {
 	const type = resolve_project_type()
 
 	console.info('\n🔄 Syncing @joshuafolkken/kit AI files\n')
-	sync_ai_copy_all(is_force)
-	sync_prettier_config(path.join(PROJECT_ROOT, 'prettier.config.js'))
-	sync_playwright_config(path.join(PROJECT_ROOT, 'playwright.config.ts'))
-	sync_deploy_vps(path.join(PROJECT_ROOT, '.github/workflows/deploy-vps.yml'))
-	sync_sonar_with_template(is_force)
-	sync_config_files(type)
+	sync_project_artifacts(type, is_force)
 	console.info('\n✅ Done.\n')
 }
 
@@ -240,6 +266,7 @@ const sync = {
 	sync_prettier_config,
 	sync_playwright_config,
 	sync_deploy_vps,
+	sync_package_manager_version,
 	migrate_prettierrc,
 }
 


### PR DESCRIPTION
closes #480