### PR TITLE
Distribute .github/dependabot.yml to consumer projects via josh sync #516

### DIFF
--- a/docs/init.md
+++ b/docs/init.md
@@ -115,6 +115,7 @@ wrangler.jsonc
 .github/workflows/sonar-qube.yml
 .github/pull_request_template.md
 .github/release.yml
+.github/dependabot.yml
 .gitignore          (from templates/gitignore)
 sonar-project.properties  (generated from GitHub repo name)
 ```

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -26,6 +26,7 @@ SECURITY.md         tsconfig.sonar.json wrangler.jsonc
 .github/workflows/sonar-qube.yml
 .github/pull_request_template.md
 .github/release.yml
+.github/dependabot.yml
 ```
 
 ### `pnpm-workspace.yaml` (merged)

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"version": "0.233.0",
+	"version": "0.234.0",
 	"name": "@joshuafolkken/kit",
 	"type": "module",
 	"license": "MIT",

--- a/scripts/init/init-logic.test.ts
+++ b/scripts/init/init-logic.test.ts
@@ -149,6 +149,7 @@ describe('get_ai_copy_files - AI and community files', () => {
 		expect(result).toContain('.github/workflows/sonar-qube.yml')
 		expect(result).toContain('.github/pull_request_template.md')
 		expect(result).toContain('.github/release.yml')
+		expect(result).toContain('.github/dependabot.yml')
 	})
 })
 

--- a/scripts/init/init-logic.ts
+++ b/scripts/init/init-logic.ts
@@ -69,6 +69,7 @@ const AI_COPY_FILES: ReadonlyArray<string> = [
 	'.github/workflows/sonar-qube.yml',
 	'.github/pull_request_template.md',
 	'.github/release.yml',
+	'.github/dependabot.yml',
 	'.claude/settings.json',
 ]
 


### PR DESCRIPTION
closes #516