### PR TITLE
Distribute publish.yml via josh sync to single-source its action pins #530

### DIFF
--- a/docs/init.md
+++ b/docs/init.md
@@ -112,6 +112,7 @@ wrangler.jsonc
 .github/workflows/ci.yml
 .github/workflows/auto-tag.yml
 .github/workflows/production.yml
+.github/workflows/publish.yml
 .github/workflows/sonar-qube.yml
 .github/pull_request_template.md
 .github/release.yml

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -23,11 +23,20 @@ SECURITY.md         tsconfig.sonar.json wrangler.jsonc
 .github/workflows/ci.yml
 .github/workflows/auto-tag.yml
 .github/workflows/production.yml
+.github/workflows/publish.yml
 .github/workflows/sonar-qube.yml
 .github/pull_request_template.md
 .github/release.yml
 .github/dependabot.yml
 ```
+
+> **GitHub Actions workflows are single-sourced by the kit.** Every consumer-facing workflow
+> (`ci.yml`, `auto-tag.yml`, `production.yml`, `publish.yml`, `sonar-qube.yml`) is overwritten on
+> each `josh sync`, so action SHA pins are bumped once in the kit and propagated to all consumers —
+> no per-consumer maintenance. The kit's own `github-actions` Dependabot is what bumps those pins at
+> the source; `josh sync` then distributes them. The `github-actions` entry in the distributed
+> `dependabot.yml` is intentionally kept as a backstop (it covers any non-kit workflow a consumer
+> adds, and finds nothing to bump for synced workflows since their pins are already current).
 
 ### `pnpm-workspace.yaml` (merged)
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"version": "0.240.0",
+	"version": "0.241.0",
 	"name": "@joshuafolkken/kit",
 	"type": "module",
 	"license": "MIT",

--- a/scripts/init/init-logic.test.ts
+++ b/scripts/init/init-logic.test.ts
@@ -146,6 +146,7 @@ describe('get_ai_copy_files - AI and community files', () => {
 		expect(result).not.toContain(CI_YML_DEST)
 		expect(result).toContain('.github/workflows/auto-tag.yml')
 		expect(result).toContain('.github/workflows/production.yml')
+		expect(result).toContain('.github/workflows/publish.yml')
 		expect(result).toContain('.github/workflows/sonar-qube.yml')
 		expect(result).toContain('.github/pull_request_template.md')
 		expect(result).toContain('.github/release.yml')

--- a/scripts/init/init-logic.ts
+++ b/scripts/init/init-logic.ts
@@ -66,6 +66,7 @@ const AI_COPY_FILES: ReadonlyArray<string> = [
 	'wrangler.jsonc',
 	'.github/workflows/auto-tag.yml',
 	'.github/workflows/production.yml',
+	'.github/workflows/publish.yml',
 	'.github/workflows/sonar-qube.yml',
 	'.github/pull_request_template.md',
 	'.github/release.yml',


### PR DESCRIPTION
closes #530