### PR TITLE
Stop distributing publish.yml via josh sync and bump sonarqube-scan-action to v8.2.0 #532

### DIFF
--- a/.github/workflows/sonar-qube.yml
+++ b/.github/workflows/sonar-qube.yml
@@ -16,6 +16,6 @@ jobs:
         with:
           fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
       - name: SonarQube Scan
-        uses: SonarSource/sonarqube-scan-action@7006c4492b2e0ee0f816d36501671557c97f5995 # v8.1.0
+        uses: SonarSource/sonarqube-scan-action@713881670b6b3676cda39549040e2d88c70d582e # v8.2.0
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/docs/init.md
+++ b/docs/init.md
@@ -112,7 +112,6 @@ wrangler.jsonc
 .github/workflows/ci.yml
 .github/workflows/auto-tag.yml
 .github/workflows/production.yml
-.github/workflows/publish.yml
 .github/workflows/sonar-qube.yml
 .github/pull_request_template.md
 .github/release.yml

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -23,7 +23,6 @@ SECURITY.md         tsconfig.sonar.json wrangler.jsonc
 .github/workflows/ci.yml
 .github/workflows/auto-tag.yml
 .github/workflows/production.yml
-.github/workflows/publish.yml
 .github/workflows/sonar-qube.yml
 .github/pull_request_template.md
 .github/release.yml
@@ -31,7 +30,7 @@ SECURITY.md         tsconfig.sonar.json wrangler.jsonc
 ```
 
 > **GitHub Actions workflows are single-sourced by the kit.** Every consumer-facing workflow
-> (`ci.yml`, `auto-tag.yml`, `production.yml`, `publish.yml`, `sonar-qube.yml`) is overwritten on
+> (`ci.yml`, `auto-tag.yml`, `production.yml`, `sonar-qube.yml`) is overwritten on
 > each `josh sync`, so action SHA pins are bumped once in the kit and propagated to all consumers —
 > no per-consumer maintenance. The kit's own `github-actions` Dependabot is what bumps those pins at
 > the source; `josh sync` then distributes them. The `github-actions` entry in the distributed

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"version": "0.241.0",
+	"version": "0.242.0",
 	"name": "@joshuafolkken/kit",
 	"type": "module",
 	"license": "MIT",

--- a/scripts/init/init-logic.test.ts
+++ b/scripts/init/init-logic.test.ts
@@ -140,13 +140,13 @@ describe('get_ai_copy_files - AI and community files', () => {
 		expect(result).toContain('CODE_OF_CONDUCT.md')
 	})
 
-	it('includes GitHub workflow and template files (except ci.yml which uses file mapping)', () => {
+	it('includes GitHub workflow and template files (except ci.yml mapping and non-distributed publish.yml)', () => {
 		const result = init_logic.get_ai_copy_files()
 
 		expect(result).not.toContain(CI_YML_DEST)
 		expect(result).toContain('.github/workflows/auto-tag.yml')
 		expect(result).toContain('.github/workflows/production.yml')
-		expect(result).toContain('.github/workflows/publish.yml')
+		expect(result).not.toContain('.github/workflows/publish.yml')
 		expect(result).toContain('.github/workflows/sonar-qube.yml')
 		expect(result).toContain('.github/pull_request_template.md')
 		expect(result).toContain('.github/release.yml')

--- a/scripts/init/init-logic.ts
+++ b/scripts/init/init-logic.ts
@@ -66,7 +66,6 @@ const AI_COPY_FILES: ReadonlyArray<string> = [
 	'wrangler.jsonc',
 	'.github/workflows/auto-tag.yml',
 	'.github/workflows/production.yml',
-	'.github/workflows/publish.yml',
 	'.github/workflows/sonar-qube.yml',
 	'.github/pull_request_template.md',
 	'.github/release.yml',


### PR DESCRIPTION
closes #532