### PR TITLE
ci.yml template: generalize the library-oriented Build-before-eslint comment #547

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"version": "0.248.0",
+	"version": "0.249.0",
 	"name": "@joshuafolkken/kit",
 	"type": "module",
 	"license": "MIT",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1425,8 +1425,8 @@ packages:
   devalue@5.8.1:
     resolution: {integrity: sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==}
 
-  electron-to-chromium@1.5.369:
-    resolution: {integrity: sha512-XM22K9FNaaCOvMMrBn1caIc8v0g6+pKt660ZbfQqUZvfil0hEzr8ZoiY7VcSLGM3L/x3rz5PqZrk+bKOOmVM9w==}
+  electron-to-chromium@1.5.370:
+    resolution: {integrity: sha512-D5tSHJReAb/Kf3Hu9F/GO4lJuSWzEWHwvQ/kKSUP7pimNgvxkSKj+gUQhHpKKACwrin7rS3byU7IxreF56rl5g==}
 
   env-paths@4.0.0:
     resolution: {integrity: sha512-pxP8eL2SwwaTRi/KHYwLYXinDs7gL3jxFcBYmEdYfZmZXbaVDvdppd0XBU8qVz03rDfKZMXg1omHCbsJjZrMsw==}
@@ -2062,8 +2062,8 @@ packages:
     peerDependencies:
       postcss: ^8.4.29
 
-  postcss-selector-parser@7.1.1:
-    resolution: {integrity: sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==}
+  postcss-selector-parser@7.1.2:
+    resolution: {integrity: sha512-Wjvt4scRFouioIInHf51IFNP4ltJ2EngJM+cZPGiqbKetBfmP3vpdPV8ID2S6JS6/jdo74N8+aEYH9lQr2C6sA==}
     engines: {node: '>=4'}
 
   postcss@8.5.15:
@@ -3276,7 +3276,7 @@ snapshots:
     dependencies:
       baseline-browser-mapping: 2.10.34
       caniuse-lite: 1.0.30001797
-      electron-to-chromium: 1.5.369
+      electron-to-chromium: 1.5.370
       node-releases: 2.0.47
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
@@ -3433,7 +3433,7 @@ snapshots:
 
   devalue@5.8.1: {}
 
-  electron-to-chromium@1.5.369: {}
+  electron-to-chromium@1.5.370: {}
 
   env-paths@4.0.0:
     dependencies:
@@ -4029,7 +4029,7 @@ snapshots:
     dependencies:
       postcss: 8.5.15
 
-  postcss-selector-parser@7.1.1:
+  postcss-selector-parser@7.1.2:
     dependencies:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
@@ -4157,7 +4157,7 @@ snapshots:
       espree: 10.4.0
       postcss: 8.5.15
       postcss-scss: 4.0.9(postcss@8.5.15)
-      postcss-selector-parser: 7.1.1
+      postcss-selector-parser: 7.1.2
       semver: 7.8.3
     optionalDependencies:
       svelte: 5.55.7(@typescript-eslint/types@8.61.0)

--- a/scripts/ci-yml-build-order.test.ts
+++ b/scripts/ci-yml-build-order.test.ts
@@ -15,7 +15,7 @@ function step_index(file_path: string, needle: string): number {
 }
 
 describe('ci.yml build order (templates/workflows/ci.yml)', () => {
-	it('builds dist/ before the eslint step so consumers can type-aware-lint against dist', () => {
+	it('builds before the eslint step so generated outputs exist for type-aware linting', () => {
 		const build_index = step_index(TEMPLATE_CI_YML, BUILD_STEP)
 		const eslint_index = step_index(TEMPLATE_CI_YML, ESLINT_STEP)
 

--- a/templates/workflows/ci.yml
+++ b/templates/workflows/ci.yml
@@ -86,9 +86,8 @@ jobs:
       - name: Run prettier check
         run: pnpm exec prettier --check .
 
-      # Build before eslint so dist/ (incl. dist/index.d.ts) exists for consumers
-      # that type-aware-lint templates which self-import the package. The same
-      # build output is reused by the size check below.
+      # Build before eslint so generated outputs exist for type-aware linting.
+      # The same build output is reused by the size check below.
       - name: Build
         run: pnpm build
 


### PR DESCRIPTION
closes #547