### PR TITLE
Fix josh init for SvelteKit library projects: detection + self devDep #576

### DIFF
--- a/docs/init.md
+++ b/docs/init.md
@@ -10,7 +10,7 @@ pnpm josh init
 
 `josh init` needs to know whether your project is SvelteKit or vanilla TypeScript.
 
-1. **Auto-detect** — if `svelte.config.js` or `svelte.config.ts` exists in the current directory, `sveltekit` is used automatically.
+1. **Auto-detect** — `sveltekit` is used automatically when either `svelte.config.js` / `svelte.config.ts` exists in the current directory **or** `@sveltejs/kit` is listed in the project's `dependencies` / `devDependencies`. The dependency check covers the newer `sv create --template library` scaffold, which ships no `svelte.config.*` and configures the `sveltekit()` plugin in `vite.config.ts` instead.
 2. **CLI flag** — pass `--type sveltekit` or `--type vanilla` to skip detection.
 3. **Interactive prompt** — if detection fails and no flag is given, you are prompted to choose.
 
@@ -65,6 +65,18 @@ The lifecycle hooks (`lefthook install` + `fix-gh-packages`) live in **`prepare`
 When a `prepare` already exists (for example a SvelteKit `svelte-kit sync`), `josh init` appends the lifecycle to it rather than replacing it. If a script already runs `fix-gh-packages`, `josh init` skips re-adding the hook so re-running it never duplicates. A kit-managed `postinstall` from an earlier version (one that runs `fix-gh-packages`) is migrated to `prepare`; a custom `postinstall` of your own is left untouched.
 
 All other toolchain tasks are available as `pnpm josh <command>` subcommands — they are **not** added as separate package scripts. Existing scripts are never overwritten.
+
+## Dependencies
+
+`josh init` adds the packages the generated config needs to `devDependencies`. An entry is only added when it is missing — an existing version is never overwritten, so re-running `josh init` is idempotent.
+
+| Package                    | Added for          | Version                                                                                                   |
+| -------------------------- | ------------------ | --------------------------------------------------------------------------------------------------------- |
+| `@joshuafolkken/kit`       | all project types  | pinned to the running kit version (the generated configs import from this package, so it must be present) |
+| `cspell`                   | SvelteKit projects | `^10.0.0`                                                                                                 |
+| `size-limit`               | SvelteKit projects | `^12.1.0`                                                                                                 |
+| `@size-limit/file`         | SvelteKit projects | `^12.1.0`                                                                                                 |
+| `rollup-plugin-visualizer` | SvelteKit projects | `^7.0.1`                                                                                                  |
 
 ### Available `pnpm josh` subcommands (all project types)
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"version": "0.260.0",
+	"version": "0.261.0",
 	"name": "@joshuafolkken/kit",
 	"type": "module",
 	"license": "MIT",

--- a/scripts/init/init-paths.test.ts
+++ b/scripts/init/init-paths.test.ts
@@ -23,6 +23,16 @@ describe('package_path', () => {
 })
 
 const PROJECT_TYPE_TEST_DIR = path.join(tmpdir(), 'init-paths-project-type-test')
+const PACKAGE_JSON_FILE = 'package.json'
+const SVELTEKIT_PACKAGE = '@sveltejs/kit'
+
+function write_project_file(filename: string, content: string): void {
+	writeFileSync(path.join(PROJECT_TYPE_TEST_DIR, filename), content)
+}
+
+function write_project_package_json(value: Record<string, unknown>): void {
+	write_project_file(PACKAGE_JSON_FILE, JSON.stringify(value))
+}
 
 describe('is_sveltekit_project', () => {
 	beforeEach(() => {
@@ -34,13 +44,28 @@ describe('is_sveltekit_project', () => {
 	})
 
 	it('returns true when svelte.config.js exists', () => {
-		writeFileSync(path.join(PROJECT_TYPE_TEST_DIR, 'svelte.config.js'), '')
+		write_project_file('svelte.config.js', '')
 		expect(is_sveltekit_project(PROJECT_TYPE_TEST_DIR)).toBe(true)
 	})
 
 	it('returns true when svelte.config.ts exists', () => {
-		writeFileSync(path.join(PROJECT_TYPE_TEST_DIR, 'svelte.config.ts'), '')
+		write_project_file('svelte.config.ts', '')
 		expect(is_sveltekit_project(PROJECT_TYPE_TEST_DIR)).toBe(true)
+	})
+
+	it('returns true when @sveltejs/kit is a devDependency without svelte.config', () => {
+		write_project_package_json({ devDependencies: { [SVELTEKIT_PACKAGE]: '^2.0.0' } })
+		expect(is_sveltekit_project(PROJECT_TYPE_TEST_DIR)).toBe(true)
+	})
+
+	it('returns true when @sveltejs/kit is a dependency without svelte.config', () => {
+		write_project_package_json({ dependencies: { [SVELTEKIT_PACKAGE]: '^2.0.0' } })
+		expect(is_sveltekit_project(PROJECT_TYPE_TEST_DIR)).toBe(true)
+	})
+
+	it('returns false when package.json lacks @sveltejs/kit and no svelte.config', () => {
+		write_project_package_json({ devDependencies: { vite: '^5.0.0' } })
+		expect(is_sveltekit_project(PROJECT_TYPE_TEST_DIR)).toBe(false)
 	})
 
 	it('returns false when no svelte.config.{js,ts} exists', () => {

--- a/scripts/init/init-paths.ts
+++ b/scripts/init/init-paths.ts
@@ -1,18 +1,42 @@
-import { existsSync } from 'node:fs'
+import { existsSync, readFileSync } from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { package_with_deps_schema } from '#scripts/schemas'
 
 const PACKAGE_DIR = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', '..')
 const PROJECT_ROOT = process.cwd()
+const SVELTEKIT_PACKAGE = '@sveltejs/kit'
 
 function package_path(relative_path: string): string {
 	return path.join(PACKAGE_DIR, relative_path)
 }
 
+function parse_json_file(file_path: string): unknown {
+	try {
+		return JSON.parse(readFileSync(file_path, 'utf8'))
+	} catch {
+		return undefined
+	}
+}
+
+// The new `sv` library template (`sv create --template library`) ships no
+// svelte.config.{js,ts} — it configures the sveltekit() plugin in vite.config.ts
+// instead — so fall back to detecting `@sveltejs/kit` in the project's dependencies.
+function has_sveltekit_dependency(project_root: string): boolean {
+	const package_json_path = path.join(project_root, 'package.json')
+	if (!existsSync(package_json_path)) return false
+	const parsed = package_with_deps_schema.safeParse(parse_json_file(package_json_path))
+	if (!parsed.success) return false
+	const deps = { ...parsed.data.dependencies, ...parsed.data.devDependencies }
+
+	return Object.hasOwn(deps, SVELTEKIT_PACKAGE)
+}
+
 function is_sveltekit_project(project_root: string): boolean {
 	return (
 		existsSync(path.join(project_root, 'svelte.config.js')) ||
-		existsSync(path.join(project_root, 'svelte.config.ts'))
+		existsSync(path.join(project_root, 'svelte.config.ts')) ||
+		has_sveltekit_dependency(project_root)
 	)
 }
 

--- a/scripts/init/init.test.ts
+++ b/scripts/init/init.test.ts
@@ -71,6 +71,36 @@ describe('install_lefthook', () => {
 	})
 })
 
+const KIT_PACKAGE_NAME = '@joshuafolkken/kit'
+const KIT_PACKAGE_JSON_PATH = fileURLToPath(new URL('../../package.json', import.meta.url))
+const KIT_VERSION = (JSON.parse(readFileSync(KIT_PACKAGE_JSON_PATH, 'utf8')) as { version: string })
+	.version
+
+function merge_development_dependencies(
+	content: string,
+	type: 'sveltekit' | 'vanilla',
+): Record<string, string> {
+	const merged = init.apply_package_json_merges(content, type)
+
+	return (JSON.parse(merged) as { devDependencies: Record<string, string> }).devDependencies
+}
+
+describe('apply_package_json_merges', () => {
+	it('adds @joshuafolkken/kit at the kit version for a sveltekit project', () => {
+		expect(merge_development_dependencies('{}\n', 'sveltekit')[KIT_PACKAGE_NAME]).toBe(KIT_VERSION)
+	})
+
+	it('adds @joshuafolkken/kit at the kit version for a vanilla project', () => {
+		expect(merge_development_dependencies('{}\n', 'vanilla')[KIT_PACKAGE_NAME]).toBe(KIT_VERSION)
+	})
+
+	it('does not overwrite an existing @joshuafolkken/kit pin', () => {
+		const existing = `${JSON.stringify({ devDependencies: { [KIT_PACKAGE_NAME]: '0.1.0' } })}\n`
+
+		expect(merge_development_dependencies(existing, 'vanilla')[KIT_PACKAGE_NAME]).toBe('0.1.0')
+	})
+})
+
 describe('copy_ai_file', () => {
 	it('writes file content to destination', () => {
 		writeFileSync(TEMPLATE_PATH, NO_REFERENCES_CONTENT)

--- a/scripts/init/init.ts
+++ b/scripts/init/init.ts
@@ -3,7 +3,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import path from 'node:path'
 import readline from 'node:readline'
 import { fileURLToPath } from 'node:url'
-import { with_package_manager_schema } from '#scripts/schemas'
+import { package_version_schema, with_package_manager_schema } from '#scripts/schemas'
 import { sync } from '#scripts/sync/sync'
 import { package_manager_version } from '#scripts/version/package-manager-version'
 import { execaSync } from 'execa'
@@ -13,6 +13,7 @@ import { init_logic, type ProjectType } from './init-logic'
 import { is_sveltekit_project, PROJECT_ROOT } from './init-paths'
 
 const PACKAGE_JSON = 'package.json'
+const KIT_PACKAGE_NAME = '@joshuafolkken/kit'
 const SAMPLE_INDENT_WIDTH = 4
 const SAMPLE_INDENT = ' '.repeat(SAMPLE_INDENT_WIDTH)
 
@@ -116,6 +117,14 @@ function get_kit_development_engines(): Record<string, unknown> {
 	return init_logic.get_development_engines_value()
 }
 
+// Pin the kit to its own published version so the generated configs (which all import
+// `@joshuafolkken/kit/...`) resolve. Exact pin matches the consumer convention.
+function get_kit_self_dependency(): Record<string, string> {
+	const { version } = package_version_schema.parse(init_actions.read_package_json(PACKAGE_JSON))
+
+	return { [KIT_PACKAGE_NAME]: version }
+}
+
 function apply_package_json_merges(content: string, type: ProjectType): string {
 	const migrated = init_logic.strip_managed_postinstall(content)
 	const merged =
@@ -125,7 +134,8 @@ function apply_package_json_merges(content: string, type: ProjectType): string {
 					migrated,
 					init_logic.get_suggested_scripts_for_content(type, migrated),
 				)
-	const with_lifecycle = init_logic.merge_prepare_lifecycle_cmd(merged)
+	const with_kit = init_logic.merge_development_dependencies(merged, get_kit_self_dependency())
+	const with_lifecycle = init_logic.merge_prepare_lifecycle_cmd(with_kit)
 	const kit_pm = get_kit_package_manager()
 	const with_pm =
 		kit_pm === undefined ? with_lifecycle : init_logic.merge_package_manager(with_lifecycle, kit_pm)


### PR DESCRIPTION
closes #576

## Summary
Fixes `josh init` for SvelteKit **library** projects (`sv create --template library`), which previously initialized as vanilla and omitted the kit itself from devDependencies.

### Issue 1 — SvelteKit misdetected as vanilla
`is_sveltekit_project` only checked for `svelte.config.{js,ts}`. The new `sv` library template ships no `svelte.config.*` (it configures the `sveltekit()` plugin in `vite.config.ts`), so projects fell back to vanilla. Detection now also matches `@sveltejs/kit` in the project's `dependencies` / `devDependencies`, parsed safely (missing file / invalid JSON → not SvelteKit).

### Issue 2 — `@joshuafolkken/kit` missing from devDependencies
The generated configs all import from `@joshuafolkken/kit`, but `josh init` never added the package itself. It is now auto-added to `devDependencies` (exact-pinned to the running kit version) on **both** the sveltekit and vanilla paths, idempotently (an existing entry is never overwritten).

### Docs
`docs/init.md`: updated the detection rule and added a Dependencies section.

## Tests
- `init-paths.test.ts`: detection via deps / devDeps, svelte.config regression, negative case.
- `init.test.ts`: kit self-dep added for sveltekit + vanilla, and idempotency.